### PR TITLE
README banner standardization (badges + sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Praxis
 
+<!-- plures-readme-banner -->
+[![CI](https://github.com/plures/praxis/actions/workflows/ci.yml/badge.svg)](https://github.com/plures/praxis/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40plures%2Fpraxis.svg)](https://www.npmjs.com/package/@plures/praxis)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+
 **Typed, visual-first application logic for Svelte, Node, and the browser.**
 
 [![npm version](https://img.shields.io/npm/v/@plures/praxis.svg)](https://www.npmjs.com/package/@plures/praxis)
@@ -1131,3 +1137,16 @@ Please review our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating.
 ---
 
 Built with ❤️ by the plures team
+
+---
+
+<!-- plures-readme-standard-sections -->
+## Overview
+
+## Install
+
+## Development
+
+## Contributing
+
+## License


### PR DESCRIPTION
This PR applies the Plures README at-a-glance standard:\n\n- Adds a top-of-README banner block (CI badge where available; placeholder where not yet configured)\n- Adds standard section headers to make repos consistent\n\nLocal-first change; non-destructive.\n\nFollow-ups:\n- For repos with placeholder CI badge, add a minimal CI workflow so the badge becomes meaningful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `README.md` (badges/section placeholders) with no impact on runtime behavior or published APIs.
> 
> **Overview**
> Adds a standardized top-of-README banner (marked by `<!-- plures-readme-banner -->`) with CI/npm/license badges.
> 
> Appends a `<!-- plures-readme-standard-sections -->` block at the end of the README with placeholder headers (`Overview`, `Install`, `Development`, `Contributing`, `License`) to align with the Plures README layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057b49964d087887c9075c57658cf21bc1938cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->