### PR TITLE
feat: Engine DX improvements — event filters, atomic step, fact dedup, checkConstraints

### DIFF
--- a/src/__tests__/edge-cases.test.ts
+++ b/src/__tests__/edge-cases.test.ts
@@ -488,7 +488,7 @@ describe('Edge Cases and Failure Paths', () => {
           if (events.some(TestEvent.is)) {
             const facts = [];
             for (let i = 0; i < 1000; i++) {
-              facts.push(TestFact.create({ index: i }));
+              facts.push({ tag: `TestFact-${i}`, payload: { index: i } });
             }
             return facts;
           }

--- a/src/__tests__/engine-dx.test.ts
+++ b/src/__tests__/engine-dx.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for engine DX improvements:
+ *   1. eventTypes filter on RuleDescriptor
+ *   2. Atomic stepWithContext()
+ *   3. Fact deduplication + maxFacts
+ *   4. checkConstraints() convenience method
+ *   5. defineRule/defineModule type inference helpers
+ */
+import { describe, it, expect } from 'vitest';
+import { createPraxisEngine, PraxisRegistry, type PraxisFact, type PraxisEvent } from '../index.js';
+import type { RuleDescriptor, ConstraintDescriptor, PraxisModule } from '../core/rules.js';
+import { defineRule, defineConstraint, defineModule } from '../dsl/index.js';
+
+interface TestContext {
+  count: number;
+  name: string;
+  items: string[];
+}
+
+// ─── 1. eventTypes filter ──────────────────────────────────────────────────
+
+describe('eventTypes filter', () => {
+  it('rule with eventTypes only fires on matching events', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'count-rule',
+      description: 'Only fires on count.increment',
+      eventTypes: 'count.increment',
+      impl: (state) => [{ tag: 'count.incremented', payload: { count: state.context.count } }],
+    });
+    registry.registerRule({
+      id: 'catch-all',
+      description: 'Fires on everything',
+      impl: () => [{ tag: 'catch-all.fired', payload: {} }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 1, name: 'test', items: [] },
+      registry,
+    });
+
+    // Fire unrelated event — only catch-all should fire
+    const r1 = engine.step([{ tag: 'name.changed', payload: {} }]);
+    const tags1 = r1.state.facts.map(f => f.tag);
+    expect(tags1).toContain('catch-all.fired');
+    expect(tags1).not.toContain('count.incremented');
+
+    // Fire matching event — both should fire
+    engine.clearFacts();
+    const r2 = engine.step([{ tag: 'count.increment', payload: {} }]);
+    const tags2 = r2.state.facts.map(f => f.tag);
+    expect(tags2).toContain('catch-all.fired');
+    expect(tags2).toContain('count.incremented');
+  });
+
+  it('rule with eventTypes array matches any of the listed tags', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'multi-event',
+      description: 'Fires on count.increment or count.decrement',
+      eventTypes: ['count.increment', 'count.decrement'],
+      impl: () => [{ tag: 'multi.fired', payload: {} }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    // Match first
+    let r = engine.step([{ tag: 'count.increment', payload: {} }]);
+    expect(r.state.facts.some(f => f.tag === 'multi.fired')).toBe(true);
+
+    engine.clearFacts();
+
+    // Match second
+    r = engine.step([{ tag: 'count.decrement', payload: {} }]);
+    expect(r.state.facts.some(f => f.tag === 'multi.fired')).toBe(true);
+
+    engine.clearFacts();
+
+    // No match
+    r = engine.step([{ tag: 'other.event', payload: {} }]);
+    expect(r.state.facts.some(f => f.tag === 'multi.fired')).toBe(false);
+  });
+
+  it('empty events array skips rules with eventTypes', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'filtered-rule',
+      description: 'Needs specific event',
+      eventTypes: 'specific.event',
+      impl: () => [{ tag: 'filtered.fired', payload: {} }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    const r = engine.step([]);
+    expect(r.state.facts).toHaveLength(0);
+  });
+});
+
+// ─── 2. Atomic stepWithContext ──────────────────────────────────────────────
+
+describe('stepWithContext', () => {
+  it('updates context before rules evaluate', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'check-context',
+      description: 'Reads context.count',
+      impl: (state) => {
+        // This should see the UPDATED count, not the old one
+        return [{ tag: 'seen-count', payload: { count: state.context.count } }];
+      },
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    const result = engine.stepWithContext(
+      (ctx) => ({ ...ctx, count: 42 }),
+      [{ tag: 'test', payload: {} }]
+    );
+
+    const seenFact = result.state.facts.find(f => f.tag === 'seen-count');
+    expect(seenFact).toBeDefined();
+    expect((seenFact!.payload as any).count).toBe(42);
+  });
+
+  it('returns proper diagnostics from constraints', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerConstraint({
+      id: 'max-count',
+      description: 'Count must be <= 100',
+      impl: (state) => state.context.count <= 100 ? true : `Count too high: ${state.context.count}`,
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    const result = engine.stepWithContext(
+      (ctx) => ({ ...ctx, count: 200 }),
+      [{ tag: 'test', payload: {} }]
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain('200');
+  });
+});
+
+// ─── 3. Fact deduplication ─────────────────────────────────────────────────
+
+describe('fact deduplication', () => {
+  it('last-write-wins deduplicates by tag (default)', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'counter',
+      description: 'Emits count fact',
+      impl: (state) => [{ tag: 'current-count', payload: { value: state.context.count } }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 1, name: '', items: [] },
+      registry,
+      // default factDedup is 'last-write-wins'
+    });
+
+    engine.step([{ tag: 'tick', payload: {} }]);
+    engine.updateContext(ctx => ({ ...ctx, count: 2 }));
+    engine.step([{ tag: 'tick', payload: {} }]);
+    engine.updateContext(ctx => ({ ...ctx, count: 3 }));
+    engine.step([{ tag: 'tick', payload: {} }]);
+
+    const facts = engine.getFacts();
+    const countFacts = facts.filter(f => f.tag === 'current-count');
+    // Should only have ONE current-count fact (the latest)
+    expect(countFacts).toHaveLength(1);
+    expect((countFacts[0].payload as any).value).toBe(3);
+  });
+
+  it('none mode accumulates all facts', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'counter',
+      description: 'Emits count fact',
+      impl: (state) => [{ tag: 'current-count', payload: { value: state.context.count } }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 1, name: '', items: [] },
+      registry,
+      factDedup: 'none',
+    });
+
+    engine.step([{ tag: 'tick', payload: {} }]);
+    engine.updateContext(ctx => ({ ...ctx, count: 2 }));
+    engine.step([{ tag: 'tick', payload: {} }]);
+
+    const countFacts = engine.getFacts().filter(f => f.tag === 'current-count');
+    expect(countFacts).toHaveLength(2);
+  });
+
+  it('maxFacts limits fact accumulation', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerRule({
+      id: 'emitter',
+      description: 'Emits unique fact each step',
+      impl: (state) => [{ tag: `fact-${state.context.count}`, payload: {} }],
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+      factDedup: 'none',
+      maxFacts: 5,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      engine.updateContext(ctx => ({ ...ctx, count: i }));
+      engine.step([{ tag: 'tick', payload: {} }]);
+    }
+
+    expect(engine.getFacts().length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ─── 4. checkConstraints convenience ───────────────────────────────────────
+
+describe('checkConstraints', () => {
+  it('returns empty array when all constraints pass', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerConstraint({
+      id: 'positive-count',
+      description: 'Count must be positive',
+      impl: (state) => state.context.count >= 0,
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 5, name: '', items: [] },
+      registry,
+    });
+
+    expect(engine.checkConstraints()).toHaveLength(0);
+  });
+
+  it('returns violations without running rules', () => {
+    const registry = new PraxisRegistry<TestContext>();
+    let ruleRan = false;
+    registry.registerRule({
+      id: 'side-effect-detector',
+      description: 'Should NOT run during checkConstraints',
+      impl: () => {
+        ruleRan = true;
+        return [{ tag: 'should-not-appear', payload: {} }];
+      },
+    });
+    registry.registerConstraint({
+      id: 'has-name',
+      description: 'Name must not be empty',
+      impl: (state) => state.context.name.length > 0 ? true : 'Name is empty',
+    });
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    const violations = engine.checkConstraints();
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toBe('Name is empty');
+    expect(ruleRan).toBe(false);
+    expect(engine.getFacts().some(f => f.tag === 'should-not-appear')).toBe(false);
+  });
+});
+
+// ─── 5. Type inference helpers ─────────────────────────────────────────────
+
+describe('type inference helpers', () => {
+  it('defineRule preserves eventTypes', () => {
+    const rule = defineRule<TestContext>({
+      id: 'typed-rule',
+      description: 'A typed rule with event filter',
+      eventTypes: ['sprint.update'],
+      impl: (state, _events) => {
+        // TypeScript should infer state.context as TestContext here
+        const _count: number = state.context.count;
+        return [];
+      },
+    });
+
+    expect(rule.id).toBe('typed-rule');
+    expect(rule.eventTypes).toEqual(['sprint.update']);
+  });
+
+  it('defineModule bundles rules and constraints with proper types', () => {
+    const mod = defineModule<TestContext>({
+      rules: [
+        {
+          id: 'mod-rule',
+          description: 'Module rule',
+          eventTypes: 'test.event',
+          impl: (state) => [{ tag: 'mod-fact', payload: { count: state.context.count } }],
+        },
+      ],
+      constraints: [
+        {
+          id: 'mod-constraint',
+          description: 'Module constraint',
+          impl: (state) => state.context.count >= 0,
+        },
+      ],
+    });
+
+    expect(mod.rules).toHaveLength(1);
+    expect(mod.constraints).toHaveLength(1);
+    expect(mod.rules[0].eventTypes).toBe('test.event');
+  });
+
+  it('defineRule + PraxisRegistry.registerModule round-trips correctly', () => {
+    const mod = defineModule<TestContext>({
+      rules: [
+        {
+          id: 'round-trip',
+          description: 'Test',
+          eventTypes: ['a', 'b'],
+          impl: () => [{ tag: 'ok', payload: {} }],
+        },
+      ],
+      constraints: [],
+    });
+
+    const registry = new PraxisRegistry<TestContext>();
+    registry.registerModule(mod);
+
+    const engine = createPraxisEngine<TestContext>({
+      initialContext: { count: 0, name: '', items: [] },
+      registry,
+    });
+
+    // Should NOT fire on unmatched event
+    let r = engine.step([{ tag: 'c', payload: {} }]);
+    expect(r.state.facts.some(f => f.tag === 'ok')).toBe(false);
+
+    // Should fire on matched event
+    r = engine.step([{ tag: 'a', payload: {} }]);
+    expect(r.state.facts.some(f => f.tag === 'ok')).toBe(true);
+  });
+});

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -28,6 +28,20 @@ export interface PraxisEngineOptions<TContext = unknown> {
   initialFacts?: PraxisFact[];
   /** Initial metadata (optional) */
   initialMeta?: Record<string, unknown>;
+  /**
+   * Fact deduplication strategy (default: 'last-write-wins').
+   *
+   * - 'none': facts accumulate without dedup (original behavior)
+   * - 'last-write-wins': only keep the latest fact per tag (most common)
+   * - 'append': keep all facts but cap at maxFacts
+   */
+  factDedup?: 'none' | 'last-write-wins' | 'append';
+  /**
+   * Maximum number of facts to retain (default: 1000).
+   * When exceeded, oldest facts are evicted (FIFO).
+   * Set to 0 for unlimited (not recommended).
+   */
+  maxFacts?: number;
 }
 
 /**
@@ -69,9 +83,13 @@ function safeClone<T>(value: T): T {
 export class LogicEngine<TContext = unknown> {
   private state: PraxisState & { context: TContext };
   private readonly registry: PraxisRegistry<TContext>;
+  private readonly factDedup: 'none' | 'last-write-wins' | 'append';
+  private readonly maxFacts: number;
 
   constructor(options: PraxisEngineOptions<TContext>) {
     this.registry = options.registry;
+    this.factDedup = options.factDedup ?? 'last-write-wins';
+    this.maxFacts = options.maxFacts ?? 1000;
     this.state = {
       context: options.initialContext,
       facts: options.initialFacts ?? [],
@@ -134,6 +152,7 @@ export class LogicEngine<TContext = unknown> {
 
     // Apply rules
     const newFacts: PraxisFact[] = [];
+    const eventTags = new Set(events.map(e => e.tag));
     for (const ruleId of config.ruleIds) {
       const rule = this.registry.getRule(ruleId);
       if (!rule) {
@@ -143,6 +162,15 @@ export class LogicEngine<TContext = unknown> {
           data: { ruleId },
         });
         continue;
+      }
+
+      // Event type filtering: if rule declares eventTypes, skip unless
+      // at least one event in the batch matches.
+      if (rule.eventTypes) {
+        const filterTags = Array.isArray(rule.eventTypes) ? rule.eventTypes : [rule.eventTypes];
+        if (!filterTags.some(t => eventTags.has(t))) {
+          continue; // No matching events — skip this rule
+        }
       }
 
       try {
@@ -157,10 +185,35 @@ export class LogicEngine<TContext = unknown> {
       }
     }
 
+    // Merge new facts with deduplication
+    let mergedFacts: PraxisFact[];
+    switch (this.factDedup) {
+      case 'last-write-wins': {
+        // Build a map keyed by tag — new facts overwrite old ones with same tag
+        const factMap = new Map<string, PraxisFact>();
+        for (const f of newState.facts) factMap.set(f.tag, f);
+        for (const f of newFacts) factMap.set(f.tag, f);
+        mergedFacts = Array.from(factMap.values());
+        break;
+      }
+      case 'append':
+        mergedFacts = [...newState.facts, ...newFacts];
+        break;
+      case 'none':
+      default:
+        mergedFacts = [...newState.facts, ...newFacts];
+        break;
+    }
+
+    // Enforce maxFacts limit (evict oldest first)
+    if (this.maxFacts > 0 && mergedFacts.length > this.maxFacts) {
+      mergedFacts = mergedFacts.slice(mergedFacts.length - this.maxFacts);
+    }
+
     // Add new facts to state
     newState = {
       ...newState,
-      facts: [...newState.facts, ...newFacts],
+      facts: mergedFacts,
     };
 
     // Check constraints
@@ -222,6 +275,35 @@ export class LogicEngine<TContext = unknown> {
   }
 
   /**
+   * Atomically update context AND process events in a single call.
+   *
+   * This avoids the fragile pattern of calling updateContext() then step()
+   * separately, where rules could see stale context if the ordering is wrong.
+   *
+   * @param updater Function that produces new context from old context
+   * @param events Events to process after context is updated
+   * @returns Result with new state and diagnostics
+   *
+   * @example
+   * engine.stepWithContext(
+   *   ctx => ({ ...ctx, sprintName: sprint.name, items: sprint.items }),
+   *   [{ tag: 'sprint.update', payload: { name: sprint.name } }]
+   * );
+   */
+  stepWithContext(
+    updater: (context: TContext) => TContext,
+    events: PraxisEvent[]
+  ): PraxisStepResult {
+    // Update context first — rules see fresh data
+    this.state = {
+      ...this.state,
+      context: updater(this.state.context),
+    };
+    // Then step with the now-current context
+    return this.step(events);
+  }
+
+  /**
    * Add facts directly (for exceptional cases).
    * Generally, facts should be added through rules.
    *
@@ -232,6 +314,22 @@ export class LogicEngine<TContext = unknown> {
       ...this.state,
       facts: [...this.state.facts, ...facts],
     };
+  }
+
+  /**
+   * Check all constraints without processing any events.
+   *
+   * Useful for validation-only scenarios (e.g., form validation,
+   * pre-save checks) where you want constraint diagnostics without
+   * triggering any rules.
+   *
+   * @returns Array of constraint violation diagnostics (empty = all passing)
+   */
+  checkConstraints(): PraxisDiagnostics[] {
+    return this.stepWithConfig([], {
+      ruleIds: [],
+      constraintIds: this.registry.getConstraintIds(),
+    }).diagnostics;
   }
 
   /**

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -61,6 +61,18 @@ export interface RuleDescriptor<TContext = unknown> {
   description: string;
   /** Implementation function */
   impl: RuleFn<TContext>;
+  /**
+   * Optional event type filter — only evaluate this rule when at least one
+   * event in the batch has a matching `tag`. When omitted, the rule runs on
+   * every step (catch-all).
+   *
+   * Accepts a single tag string or an array of tags.
+   *
+   * @example
+   * { id: 'sprint-behind', eventTypes: ['sprint.update'], impl: ... }
+   * { id: 'note-check', eventTypes: 'note.update', impl: ... }
+   */
+  eventTypes?: string | string[];
   /** Optional contract for rule behavior */
   contract?: Contract;
   /** Optional metadata */

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -85,6 +85,11 @@ export interface DefineRuleOptions<TContext = unknown> {
   id: string;
   description: string;
   impl: RuleFn<TContext>;
+  /**
+   * Optional event type filter — only evaluate this rule when at least one
+   * event in the batch has a matching `tag`. Accepts a single tag or array.
+   */
+  eventTypes?: string | string[];
   contract?: Contract;
   meta?: Record<string, unknown>;
 }
@@ -115,6 +120,7 @@ export function defineRule<TContext = unknown>(
     id: options.id,
     description: options.description,
     impl: options.impl,
+    eventTypes: options.eventTypes,
     contract,
     meta,
   };


### PR DESCRIPTION
## Five improvements for application developers

### 1. Event type filtering (`RuleDescriptor.eventTypes`)
Rules declare which events they care about — skipped otherwise. Scales to 50+ rules.
```ts
defineRule({
  id: 'sprint-check',
  eventTypes: ['sprint.update'],
  impl: (state, events) => { ... }
});
```

### 2. Atomic `stepWithContext()`
Updates context AND steps in one call — rules always see fresh data.
```ts
engine.stepWithContext(
  ctx => ({ ...ctx, items: sprint.items }),
  [{ tag: 'sprint.update', payload: {} }]
);
```

### 3. Fact deduplication (`factDedup`)
- `'last-write-wins'` (default): latest fact per tag survives
- `'append'`: keep all, cap at maxFacts
- `'none'`: original behavior

Plus `maxFacts` (default 1000) — prevents unbounded accumulation.

### 4. `checkConstraints()` convenience
Runs constraints only (no rules) — perfect for form validation.
```ts
const violations = engine.checkConstraints();
```

### 5. `eventTypes` in DSL
`defineRule()` flows `eventTypes` through to the engine. Fully backward compatible.

### Tests
- 13 new tests covering all five features
- 440 existing tests pass
- Only `cli-validate` excluded (pre-existing: needs build artifacts)