### PR TITLE
feat(mcp): Praxis MCP Server for AI assistant integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
       "import": "./dist/node/components/index.js",
       "require": "./dist/node/components/index.cjs",
       "default": "./dist/node/components/index.js"
+    },
+    "./mcp": {
+      "types": "./dist/node/mcp/index.d.ts",
+      "import": "./dist/node/mcp/index.js",
+      "require": "./dist/node/mcp/index.cjs",
+      "default": "./dist/node/mcp/index.js"
     }
   },
   "files": [
@@ -123,9 +129,11 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@plures/pluresdb": "^2.9.7",
     "commander": "^14.0.2",
     "js-yaml": "^4.1.1",
-    "@plures/pluresdb": "^2.9.7"
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "svelte": "^5.46.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
       '@plures/pluresdb':
         specifier: ^2.9.7
         version: 2.9.7
@@ -17,6 +20,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
@@ -343,6 +349,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hyperswarm/secret-stream@6.9.1':
     resolution: {integrity: sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==}
 
@@ -361,6 +373,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@plures/pluresdb@2.9.7':
     resolution: {integrity: sha512-q706q/PyGUsQ7lNecpkMck50aNcy+TdSEcFJIDNC11hp47ad9wQa6OZ7j2zGxiIc28o5/EZasIsa95LuVb6AfQ==}
@@ -599,6 +621,17 @@ packages:
   adaptive-timeout@1.0.1:
     resolution: {integrity: sha512-+seGiBtHqbnyZ0Quq/ZGxxwP66153WBABawa07/QeyuPFzbduPBjiGQAyCiriiLDzt3dkbMBskSlfqtRwblK8Q==}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -780,6 +813,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -866,16 +903,36 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -938,6 +995,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -962,6 +1023,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -972,6 +1037,12 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -979,6 +1050,12 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   kademlia-routing-table@1.0.6:
     resolution: {integrity: sha512-Ve6jwIlUCYvUzBnXnzVRHDZCFgXURW9gmF3r7n05kZs/2rNbLHXwGdcq0qIaSwdmJCvtosgR4JensnVU65hzNQ==}
@@ -1076,6 +1153,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -1092,6 +1173,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -1151,6 +1236,10 @@ packages:
     resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
     engines: {bare: '>=1.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1183,6 +1272,14 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shuffled-priority-queue@2.1.0:
     resolution: {integrity: sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==}
@@ -1494,6 +1591,11 @@ packages:
   which-runtime@1.3.2:
     resolution: {integrity: sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1522,6 +1624,14 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -1603,6 +1713,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@hyperswarm/secret-stream@6.9.1(bare-events@2.8.2)':
     dependencies:
       b4a: 1.8.0
@@ -1640,6 +1754,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@plures/pluresdb@2.9.7':
     dependencies:
@@ -1849,6 +1985,17 @@ snapshots:
     dependencies:
       xache: 1.2.1
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
@@ -2027,6 +2174,12 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2140,7 +2293,18 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -2175,7 +2339,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -2240,6 +2408,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.8: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2319,6 +2489,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-promise@4.0.0: {}
@@ -2327,11 +2499,19 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  isexe@2.0.0: {}
+
+  jose@6.2.2: {}
+
   joycon@3.1.1: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   kademlia-routing-table@1.0.6:
     dependencies:
@@ -2430,6 +2610,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-key@3.1.1: {}
+
   path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
@@ -2439,6 +2621,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -2502,6 +2686,8 @@ snapshots:
       bare-addon-resolve: 1.10.0
     transitivePeerDependencies:
       - bare-url
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -2578,6 +2764,12 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shuffled-priority-queue@2.1.0:
     dependencies:
@@ -2892,6 +3084,10 @@ snapshots:
 
   which-runtime@1.3.2: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2910,3 +3106,9 @@ snapshots:
       - react-native-b4a
 
   zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for Praxis MCP Server
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPraxisMcpServer } from '../mcp/server.js';
+import { PraxisRegistry } from '../core/rules.js';
+import { RuleResult, fact } from '../core/rule-result.js';
+import type { PraxisModule } from '../core/rules.js';
+import type { Contract } from '../decision-ledger/types.js';
+
+// ─── Test Fixtures ──────────────────────────────────────────────────────────
+
+interface TestContext {
+  counter: number;
+  name: string;
+}
+
+const incrementContract: Contract = {
+  ruleId: 'test/increment',
+  behavior: 'Increments counter when increment event fires',
+  examples: [
+    { given: 'counter is 5', when: 'increment event fires', then: 'counter.incremented emitted with value 6' },
+  ],
+  invariants: ['Counter must always increase by 1'],
+};
+
+const testModule: PraxisModule<TestContext> = {
+  rules: [
+    {
+      id: 'test/increment',
+      description: 'Increments the counter',
+      eventTypes: 'counter.increment',
+      contract: incrementContract,
+      impl: (state, events) => {
+        const hasIncrement = events.some(e => e.tag === 'counter.increment');
+        if (!hasIncrement) return RuleResult.skip('No increment event');
+        return RuleResult.emit([
+          fact('counter.incremented', { value: state.context.counter + 1 }),
+        ]);
+      },
+    },
+    {
+      id: 'test/greet',
+      description: 'Emits greeting when greet event fires',
+      eventTypes: 'greet',
+      contract: {
+        ruleId: 'test/greet',
+        behavior: 'Emits greeting fact with name',
+        examples: [
+          { given: 'name is Alice', when: 'greet event fires', then: 'greeting emitted for Alice' },
+        ],
+        invariants: ['Greeting must include the name from context'],
+      },
+      impl: (state, events) => {
+        const hasGreet = events.some(e => e.tag === 'greet');
+        if (!hasGreet) return RuleResult.skip('No greet event');
+        return RuleResult.emit([
+          fact('greeting', { message: `Hello, ${state.context.name}!` }),
+        ]);
+      },
+    },
+  ],
+  constraints: [
+    {
+      id: 'test/positive-counter',
+      description: 'Counter must be non-negative',
+      contract: {
+        ruleId: 'test/positive-counter',
+        behavior: 'Ensures counter is never negative',
+        examples: [
+          { given: 'counter is 0', when: 'checked', then: 'passes' },
+          { given: 'counter is -1', when: 'checked', then: 'fails' },
+        ],
+        invariants: ['Counter >= 0'],
+      },
+      impl: (state) => {
+        if (state.context.counter < 0) return 'Counter must be non-negative';
+        return true;
+      },
+    },
+  ],
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Praxis MCP Server', () => {
+  let registry: PraxisRegistry<TestContext>;
+
+  beforeEach(() => {
+    registry = new PraxisRegistry<TestContext>({
+      compliance: { enabled: false },
+    });
+    registry.registerModule(testModule);
+  });
+
+  describe('createPraxisMcpServer', () => {
+    it('should create a server with engine and mcpServer', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 0, name: 'Test' },
+        registry,
+      });
+
+      expect(server).toBeDefined();
+      expect(server.engine).toBeDefined();
+      expect(server.mcpServer).toBeDefined();
+      expect(server.start).toBeInstanceOf(Function);
+    });
+
+    it('should accept custom name and version', () => {
+      const server = createPraxisMcpServer({
+        name: 'my-praxis',
+        version: '2.0.0',
+        initialContext: { counter: 0, name: 'Test' },
+        registry,
+      });
+
+      expect(server).toBeDefined();
+    });
+  });
+
+  describe('engine operations via MCP server', () => {
+    it('should expose a working engine that can step', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 5, name: 'Alice' },
+        registry,
+      });
+
+      const result = server.engine.step([{ tag: 'counter.increment', payload: {} }]);
+      expect(result.state.facts).toContainEqual(
+        expect.objectContaining({ tag: 'counter.incremented', payload: { value: 6 } }),
+      );
+    });
+
+    it('should get current facts from engine', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 0, name: 'Test' },
+        registry,
+        initialFacts: [{ tag: 'init', payload: { started: true } }],
+      });
+
+      const facts = server.engine.getFacts();
+      expect(facts).toContainEqual(
+        expect.objectContaining({ tag: 'init' }),
+      );
+    });
+
+    it('should handle rule evaluation via engine', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 10, name: 'Bob' },
+        registry,
+      });
+
+      const rule = registry.getRule('test/greet');
+      expect(rule).toBeDefined();
+
+      const state = server.engine.getState();
+      const events = [{ tag: 'greet', payload: {} }];
+      const stateWithEvents = { ...state, events };
+      const result = rule!.impl(stateWithEvents as Parameters<typeof rule!.impl>[0], events);
+
+      expect(result).toBeInstanceOf(RuleResult);
+      const rr = result as RuleResult;
+      expect(rr.kind).toBe('emit');
+      expect(rr.facts).toContainEqual(
+        expect.objectContaining({ tag: 'greeting', payload: { message: 'Hello, Bob!' } }),
+      );
+    });
+
+    it('should skip rule when no matching events', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 0, name: 'Test' },
+        registry,
+      });
+
+      const rule = registry.getRule('test/increment');
+      const state = server.engine.getState();
+      const events = [{ tag: 'unrelated', payload: {} }];
+      const stateWithEvents = { ...state, events };
+      const result = rule!.impl(stateWithEvents as Parameters<typeof rule!.impl>[0], events);
+
+      expect(result).toBeInstanceOf(RuleResult);
+      expect((result as RuleResult).kind).toBe('skip');
+    });
+  });
+
+  describe('registry introspection', () => {
+    it('should list all rules', () => {
+      const rules = registry.getAllRules();
+      expect(rules).toHaveLength(2);
+      expect(rules.map(r => r.id)).toContain('test/increment');
+      expect(rules.map(r => r.id)).toContain('test/greet');
+    });
+
+    it('should list all constraints', () => {
+      const constraints = registry.getAllConstraints();
+      expect(constraints).toHaveLength(1);
+      expect(constraints[0].id).toBe('test/positive-counter');
+    });
+
+    it('should provide contract details for rules', () => {
+      const rule = registry.getRule('test/increment');
+      expect(rule?.contract).toBeDefined();
+      expect(rule?.contract?.behavior).toContain('Increments counter');
+      expect(rule?.contract?.examples).toHaveLength(1);
+      expect(rule?.contract?.invariants).toContain('Counter must always increase by 1');
+    });
+  });
+
+  describe('completeness audit integration', () => {
+    it('should run audit via engine', async () => {
+      const { auditCompleteness, formatReport } = await import('../core/completeness.js');
+
+      const manifest = {
+        branches: [
+          {
+            location: 'test.ts:1',
+            condition: 'counter > 0',
+            kind: 'domain' as const,
+            coveredBy: 'test/increment',
+          },
+        ],
+        stateFields: [
+          { source: 'store', field: 'counter', inContext: true, usedByRule: true },
+        ],
+        transitions: [
+          { description: 'increment counter', eventTag: 'counter.increment', location: 'test.ts:5' },
+        ],
+        rulesNeedingContracts: ['test/increment', 'test/greet'],
+      };
+
+      const rulesWithContracts = registry.getAllRules()
+        .filter(r => r.contract)
+        .map(r => r.id);
+
+      const report = auditCompleteness(
+        manifest,
+        registry.getRuleIds(),
+        registry.getConstraintIds(),
+        rulesWithContracts,
+      );
+
+      expect(report.score).toBeGreaterThan(0);
+      expect(report.rating).toBeDefined();
+      expect(formatReport(report)).toContain('Praxis Completeness');
+    });
+  });
+
+  describe('suggestion engine', () => {
+    it('should generate rule suggestions for behavioral gaps', () => {
+      // Test the suggestId logic indirectly through server creation
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 0, name: 'Test' },
+        registry,
+      });
+
+      expect(server).toBeDefined();
+    });
+  });
+
+  describe('step and state management', () => {
+    it('should step engine and accumulate facts', () => {
+      const server = createPraxisMcpServer({
+        initialContext: { counter: 5, name: 'Alice' },
+        registry,
+      });
+
+      // Step with increment event
+      const result1 = server.engine.step([{ tag: 'counter.increment', payload: {} }]);
+      expect(result1.state.facts.some(f => f.tag === 'counter.incremented')).toBe(true);
+
+      // Step with greet event
+      const result2 = server.engine.step([{ tag: 'greet', payload: {} }]);
+      expect(result2.state.facts.some(f => f.tag === 'greeting')).toBe(true);
+    });
+
+    it('should check constraints after step', () => {
+      const negativeRegistry = new PraxisRegistry<TestContext>({
+        compliance: { enabled: false },
+      });
+      negativeRegistry.registerModule(testModule);
+
+      const server = createPraxisMcpServer({
+        initialContext: { counter: -1, name: 'Test' },
+        registry: negativeRegistry,
+      });
+
+      const result = server.engine.step([{ tag: 'counter.increment', payload: {} }]);
+      // The constraint should report a violation for negative counter
+      const violation = result.diagnostics.find(
+        d => d.kind === 'constraint-violation' && d.message.includes('non-negative'),
+      );
+      expect(violation).toBeDefined();
+    });
+  });
+
+  describe('contract coverage', () => {
+    it('should track which rules have contracts', () => {
+      const rules = registry.getAllRules();
+      const withContracts = rules.filter(r => r.contract);
+      expect(withContracts).toHaveLength(2); // both test rules have contracts
+    });
+
+    it('should track which constraints have contracts', () => {
+      const constraints = registry.getAllConstraints();
+      const withContracts = constraints.filter(c => c.contract);
+      expect(withContracts).toHaveLength(1);
+    });
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -239,6 +239,34 @@ cloudCmd
     }
   });
 
+// MCP server command
+program
+  .command('mcp')
+  .description('Start the Praxis MCP server (Model Context Protocol) for AI assistant integration')
+  .option('--name <name>', 'Server name', '@plures/praxis')
+  .option('--version <version>', 'Server version', '1.0.0')
+  .action(async (options) => {
+    try {
+      const { createPraxisMcpServer } = await import('../mcp/server.js');
+      const { PraxisRegistry } = await import('../core/rules.js');
+
+      const registry = new PraxisRegistry({
+        compliance: { enabled: false },
+      });
+      const server = createPraxisMcpServer({
+        name: options.name,
+        version: options.version,
+        initialContext: {},
+        registry,
+      });
+
+      await server.start();
+    } catch (error) {
+      console.error('Error starting MCP server:', error);
+      process.exit(1);
+    }
+  });
+
 // Verify command
 program
   .command('verify <type>')

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Praxis MCP Module
+ *
+ * Public API for the MCP (Model Context Protocol) server.
+ * Exposes Praxis engine operations as AI-consumable tools.
+ *
+ * @example
+ * ```ts
+ * import { createPraxisMcpServer } from '@plures/praxis/mcp';
+ * ```
+ */
+
+export { createPraxisMcpServer } from './server.js';
+export type {
+  PraxisMcpServerOptions,
+  InspectInput,
+  InspectOutput,
+  RuleInfo,
+  ConstraintInfo,
+  EvaluateInput,
+  EvaluateOutput,
+  AuditInput,
+  AuditOutput,
+  SuggestInput,
+  SuggestOutput,
+  StepInput,
+  StepOutput,
+  FactsOutput,
+  ContractsInput,
+  ContractsOutput,
+  ContractInfo,
+  GatesInput,
+} from './types.js';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,485 @@
+/**
+ * Praxis MCP Server
+ *
+ * Exposes Praxis engine operations as MCP tools for AI assistants.
+ * Supports both stdio transport (CLI usage) and library import.
+ *
+ * Tools:
+ * - praxis.inspect — list all registered rules, constraints, contracts
+ * - praxis.evaluate — run a rule against given events
+ * - praxis.audit — run completeness audit against a manifest
+ * - praxis.suggest — suggest rules/constraints for a gap
+ * - praxis.facts — get current fact state
+ * - praxis.step — step the engine with events
+ * - praxis.contracts — list all contracts with coverage status
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { LogicEngine } from '../core/engine.js';
+import { RuleResult } from '../core/rule-result.js';
+import { auditCompleteness, formatReport } from '../core/completeness.js';
+import { getContractFromDescriptor } from '../decision-ledger/types.js';
+import type {
+  PraxisMcpServerOptions,
+  InspectOutput,
+  EvaluateOutput,
+  StepOutput,
+  FactsOutput,
+  ContractsOutput,
+  AuditOutput,
+  SuggestOutput,
+  RuleInfo,
+  ConstraintInfo,
+} from './types.js';
+
+/**
+ * Create a Praxis MCP server with all tools registered.
+ *
+ * @example
+ * ```ts
+ * import { createPraxisMcpServer } from '@plures/praxis/mcp';
+ * import { PraxisRegistry } from '@plures/praxis';
+ *
+ * const registry = new PraxisRegistry();
+ * // ... register rules ...
+ *
+ * const server = createPraxisMcpServer({
+ *   initialContext: {},
+ *   registry,
+ * });
+ *
+ * // Start via stdio for CLI usage
+ * await server.start();
+ *
+ * // Or use the McpServer instance directly
+ * const mcpServer = server.mcpServer;
+ * ```
+ */
+export function createPraxisMcpServer<TContext = unknown>(
+  options: PraxisMcpServerOptions<TContext>,
+) {
+  const {
+    name = '@plures/praxis',
+    version = '1.0.0',
+    initialContext,
+    registry,
+    initialFacts,
+  } = options;
+
+  // Create the engine that backs all operations
+  const engine = new LogicEngine<TContext>({
+    initialContext,
+    registry,
+    initialFacts,
+  });
+
+  // Create MCP server
+  const server = new McpServer({
+    name,
+    version,
+  });
+
+  // ── praxis.inspect ──────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.inspect',
+    'List all registered rules, constraints, and their contracts',
+    {
+      filter: z.string().optional().describe('Filter rule/constraint IDs by pattern (substring match)'),
+      includeContracts: z.boolean().optional().describe('Include full contract details (default: false)'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const filter = params.filter;
+      const includeContracts = params.includeContracts ?? false;
+
+      let rules = registry.getAllRules();
+      let constraints = registry.getAllConstraints();
+
+      if (filter) {
+        rules = rules.filter(r => r.id.includes(filter));
+        constraints = constraints.filter(c => c.id.includes(filter));
+      }
+
+      const ruleInfos: RuleInfo[] = rules.map(r => {
+        const contract = getContractFromDescriptor(r);
+        return {
+          id: r.id,
+          description: r.description,
+          eventTypes: r.eventTypes,
+          hasContract: !!contract,
+          contract: includeContracts ? contract : undefined,
+          meta: r.meta,
+        };
+      });
+
+      const constraintInfos: ConstraintInfo[] = constraints.map(c => {
+        const contract = getContractFromDescriptor(c);
+        return {
+          id: c.id,
+          description: c.description,
+          hasContract: !!contract,
+          contract: includeContracts ? contract : undefined,
+          meta: c.meta,
+        };
+      });
+
+      const output: InspectOutput = {
+        rules: ruleInfos,
+        constraints: constraintInfos,
+        summary: {
+          totalRules: ruleInfos.length,
+          totalConstraints: constraintInfos.length,
+          rulesWithContracts: ruleInfos.filter(r => r.hasContract).length,
+          constraintsWithContracts: constraintInfos.filter(c => c.hasContract).length,
+        },
+      };
+
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── praxis.evaluate ─────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.evaluate',
+    'Run a specific rule against given events and return the result',
+    {
+      ruleId: z.string().describe('The rule ID to evaluate'),
+      events: z.array(z.object({
+        tag: z.string(),
+        payload: z.unknown(),
+      })).describe('Events to process through the rule'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const rule = registry.getRule(params.ruleId);
+      if (!rule) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: `Rule "${params.ruleId}" not found` }) }],
+        };
+      }
+
+      const state = engine.getState();
+      const stateWithEvents = { ...state, events: params.events };
+
+      try {
+        const rawResult = rule.impl(stateWithEvents as Parameters<typeof rule.impl>[0], params.events);
+
+        let output: EvaluateOutput;
+        if (rawResult instanceof RuleResult) {
+          output = {
+            ruleId: params.ruleId,
+            resultKind: rawResult.kind,
+            facts: rawResult.facts,
+            retractedTags: rawResult.retractTags,
+            reason: rawResult.reason,
+            diagnostics: [],
+          };
+        } else if (Array.isArray(rawResult)) {
+          output = {
+            ruleId: params.ruleId,
+            resultKind: 'emit',
+            facts: rawResult,
+            retractedTags: [],
+            diagnostics: [],
+          };
+        } else {
+          output = {
+            ruleId: params.ruleId,
+            resultKind: 'noop',
+            facts: [],
+            retractedTags: [],
+            diagnostics: [],
+          };
+        }
+
+        return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              error: `Rule evaluation failed: ${error instanceof Error ? error.message : String(error)}`,
+              ruleId: params.ruleId,
+            }),
+          }],
+        };
+      }
+    },
+  );
+
+  // ── praxis.audit ────────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.audit',
+    'Run completeness audit against a manifest and return the report',
+    {
+      branches: z.array(z.object({
+        location: z.string(),
+        condition: z.string(),
+        kind: z.enum(['domain', 'invariant', 'ui', 'transport', 'wiring', 'transform']),
+        coveredBy: z.string().nullable(),
+        note: z.string().optional(),
+      })).describe('Logic branches to audit'),
+      stateFields: z.array(z.object({
+        source: z.string(),
+        field: z.string(),
+        inContext: z.boolean(),
+        usedByRule: z.boolean(),
+      })).describe('State fields to check context coverage'),
+      transitions: z.array(z.object({
+        description: z.string(),
+        eventTag: z.string().nullable(),
+        location: z.string(),
+      })).describe('State transitions to check event coverage'),
+      rulesNeedingContracts: z.array(z.string()).describe('Rule IDs that should have contracts'),
+      threshold: z.number().optional().describe('Minimum passing score (default: 90)'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const rulesWithContracts = registry.getAllRules()
+        .filter(r => getContractFromDescriptor(r))
+        .map(r => r.id);
+
+      const report = auditCompleteness(
+        {
+          branches: params.branches,
+          stateFields: params.stateFields,
+          transitions: params.transitions,
+          rulesNeedingContracts: params.rulesNeedingContracts,
+        },
+        registry.getRuleIds(),
+        registry.getConstraintIds(),
+        rulesWithContracts,
+        { threshold: params.threshold },
+      );
+
+      const output: AuditOutput = {
+        report,
+        formatted: formatReport(report),
+      };
+
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── praxis.suggest ──────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.suggest',
+    'Given a gap or description, suggest rules/constraints to add',
+    {
+      gap: z.string().describe('Description of the gap or failing expectation'),
+      context: z.record(z.string(), z.unknown()).optional().describe('Current context for suggestions'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const existingRules = registry.getAllRules();
+      const _constraints = registry.getAllConstraints();
+      void _constraints; // used for future constraint-aware suggestions
+      const suggestions: SuggestOutput['suggestions'] = [];
+
+      // Analyze gap description against existing rules
+      const gapLower = params.gap.toLowerCase();
+
+      // Check if any existing rule partially covers this
+      const relatedRules = existingRules.filter(r =>
+        r.description.toLowerCase().includes(gapLower) ||
+        gapLower.includes(r.id.toLowerCase()),
+      );
+
+      if (relatedRules.length > 0) {
+        // Suggest adding a constraint to complement existing rules
+        for (const rule of relatedRules) {
+          suggestions.push({
+            type: 'constraint',
+            id: `${rule.id}/guard`,
+            description: `Add a constraint to guard the behavior described by rule "${rule.id}"`,
+            rationale: `Rule "${rule.id}" (${rule.description}) exists but may not fully cover: ${params.gap}`,
+          });
+        }
+      }
+
+      // If gap mentions validation/invariant-like terms, suggest constraint
+      const invariantTerms = ['must', 'never', 'always', 'require', 'valid', 'invalid', 'prevent'];
+      if (invariantTerms.some(t => gapLower.includes(t))) {
+        suggestions.push({
+          type: 'constraint',
+          id: suggestId(params.gap, 'constraint'),
+          description: `Constraint: ${params.gap}`,
+          rationale: 'Gap description contains invariant language — a constraint would encode this guarantee',
+        });
+      }
+
+      // If gap mentions behavior/action terms, suggest rule
+      const ruleTerms = ['when', 'if', 'show', 'emit', 'trigger', 'display', 'update'];
+      if (ruleTerms.some(t => gapLower.includes(t))) {
+        suggestions.push({
+          type: 'rule',
+          id: suggestId(params.gap, 'rule'),
+          description: `Rule: ${params.gap}`,
+          rationale: 'Gap description contains conditional behavior — a rule would implement this logic',
+        });
+      }
+
+      // Check if relevant rules lack contracts
+      const contractGaps = registry.getContractGaps();
+      if (contractGaps.length > 0) {
+        const relatedGaps = contractGaps.filter(g =>
+          gapLower.includes(g.ruleId.toLowerCase()),
+        );
+        for (const g of relatedGaps) {
+          suggestions.push({
+            type: 'contract',
+            id: g.ruleId,
+            description: `Add contract for "${g.ruleId}" — missing: ${g.missing.join(', ')}`,
+            rationale: `Related rule "${g.ruleId}" lacks a contract, which could prevent this gap`,
+          });
+        }
+      }
+
+      // Suggest an event if the gap describes a state transition
+      const eventTerms = ['transition', 'change', 'happen', 'occur', 'fire', 'dispatch'];
+      if (eventTerms.some(t => gapLower.includes(t))) {
+        suggestions.push({
+          type: 'event',
+          id: suggestId(params.gap, 'event'),
+          description: `Event for: ${params.gap}`,
+          rationale: 'Gap description suggests a state transition — an event would make it observable',
+        });
+      }
+
+      // Fallback: always suggest at least a rule
+      if (suggestions.length === 0) {
+        suggestions.push({
+          type: 'rule',
+          id: suggestId(params.gap, 'rule'),
+          description: `Rule: ${params.gap}`,
+          rationale: 'No existing rules or constraints cover this gap — a new rule is recommended',
+        });
+      }
+
+      const output: SuggestOutput = { suggestions };
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── praxis.facts ────────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.facts',
+    'Get the current fact state of the engine',
+    {},
+    async (): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const facts = engine.getFacts();
+      const output: FactsOutput = {
+        facts,
+        count: facts.length,
+      };
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── praxis.step ─────────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.step',
+    'Step the engine with events and return the new state',
+    {
+      events: z.array(z.object({
+        tag: z.string(),
+        payload: z.unknown(),
+      })).describe('Events to process'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const result = engine.step(params.events);
+      const output: StepOutput = {
+        facts: result.state.facts,
+        diagnostics: result.diagnostics,
+        factCount: result.state.facts.length,
+      };
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── praxis.contracts ────────────────────────────────────────────────────
+
+  server.tool(
+    'praxis.contracts',
+    'List all contracts with their coverage status',
+    {
+      filter: z.string().optional().describe('Filter by rule/constraint ID (substring match)'),
+    },
+    async (params): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
+      const rules = registry.getAllRules();
+      const constraints = registry.getAllConstraints();
+
+      type LocalContractInfo = {
+        ruleId: string;
+        hasContract: boolean;
+        contract?: import('../decision-ledger/types.js').Contract;
+        type: 'rule' | 'constraint';
+      };
+
+      let contracts: LocalContractInfo[] = [
+        ...rules.map(r => ({
+          ruleId: r.id,
+          hasContract: !!getContractFromDescriptor(r),
+          contract: getContractFromDescriptor(r),
+          type: 'rule' as const,
+        })),
+        ...constraints.map(c => ({
+          ruleId: c.id,
+          hasContract: !!getContractFromDescriptor(c),
+          contract: getContractFromDescriptor(c),
+          type: 'constraint' as const,
+        })),
+      ];
+
+      if (params.filter) {
+        contracts = contracts.filter(c => c.ruleId.includes(params.filter!));
+      }
+
+      const total = contracts.length;
+      const withContracts = contracts.filter(c => c.hasContract).length;
+
+      const output: ContractsOutput = {
+        contracts,
+        coverage: {
+          total,
+          withContracts,
+          percentage: total > 0 ? Math.round((withContracts / total) * 100) : 100,
+        },
+      };
+
+      return { content: [{ type: 'text', text: JSON.stringify(output, null, 2) }] };
+    },
+  );
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  return {
+    /** The underlying MCP server instance */
+    mcpServer: server,
+    /** The underlying Praxis engine */
+    engine,
+    /** Start the server on stdio transport */
+    async start(): Promise<void> {
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+    },
+  };
+}
+
+/**
+ * Generate a suggested ID from a gap description and type.
+ */
+function suggestId(description: string, type: string): string {
+  const slug = description
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 3)
+    .join('-');
+  return `suggested/${type}/${slug}`;
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,161 @@
+/**
+ * Praxis MCP Server — Types
+ *
+ * Types for the MCP (Model Context Protocol) server that exposes
+ * Praxis engine operations as tools for AI assistants.
+ */
+
+import type { PraxisEvent, PraxisFact, PraxisDiagnostics } from '../core/protocol.js';
+import type { CompletenessReport, LogicBranch, StateField, StateTransition } from '../core/completeness.js';
+import type { Contract } from '../decision-ledger/types.js';
+
+// ─── Tool Input Types ───────────────────────────────────────────────────────
+
+export interface InspectInput {
+  /** Filter by rule/constraint ID pattern (glob-like) */
+  filter?: string;
+  /** Include contract details */
+  includeContracts?: boolean;
+}
+
+export interface EvaluateInput {
+  /** Rule ID to evaluate */
+  ruleId: string;
+  /** Events to process */
+  events: PraxisEvent[];
+}
+
+export interface AuditInput {
+  /** Completeness manifest */
+  manifest: {
+    branches: LogicBranch[];
+    stateFields: StateField[];
+    transitions: StateTransition[];
+    rulesNeedingContracts: string[];
+  };
+  /** Minimum passing score (default: 90) */
+  threshold?: number;
+}
+
+export interface CheckExpectationsInput {
+  /** Expectation set name to verify */
+  setName?: string;
+}
+
+export interface SuggestInput {
+  /** Description of the gap or failing expectation */
+  gap: string;
+  /** Current context for suggestions */
+  context?: Record<string, unknown>;
+}
+
+export interface StepInput {
+  /** Events to step the engine with */
+  events: PraxisEvent[];
+}
+
+export interface ContractsInput {
+  /** Filter by rule ID pattern */
+  filter?: string;
+}
+
+export interface GatesInput {
+  /** Filter by gate name */
+  filter?: string;
+}
+
+// ─── Tool Output Types ──────────────────────────────────────────────────────
+
+export interface RuleInfo {
+  id: string;
+  description: string;
+  eventTypes?: string | string[];
+  hasContract: boolean;
+  contract?: Contract;
+  meta?: Record<string, unknown>;
+}
+
+export interface ConstraintInfo {
+  id: string;
+  description: string;
+  hasContract: boolean;
+  contract?: Contract;
+  meta?: Record<string, unknown>;
+}
+
+export interface InspectOutput {
+  rules: RuleInfo[];
+  constraints: ConstraintInfo[];
+  summary: {
+    totalRules: number;
+    totalConstraints: number;
+    rulesWithContracts: number;
+    constraintsWithContracts: number;
+  };
+}
+
+export interface EvaluateOutput {
+  ruleId: string;
+  resultKind: 'emit' | 'noop' | 'skip' | 'retract';
+  facts: PraxisFact[];
+  retractedTags: string[];
+  reason?: string;
+  diagnostics: PraxisDiagnostics[];
+}
+
+export interface AuditOutput {
+  report: CompletenessReport;
+  formatted: string;
+}
+
+export interface SuggestOutput {
+  suggestions: Array<{
+    type: 'rule' | 'constraint' | 'contract' | 'event';
+    id: string;
+    description: string;
+    rationale: string;
+  }>;
+}
+
+export interface StepOutput {
+  facts: PraxisFact[];
+  diagnostics: PraxisDiagnostics[];
+  factCount: number;
+}
+
+export interface ContractInfo {
+  ruleId: string;
+  hasContract: boolean;
+  contract?: Contract;
+  type: 'rule' | 'constraint';
+}
+
+export interface ContractsOutput {
+  contracts: ContractInfo[];
+  coverage: {
+    total: number;
+    withContracts: number;
+    percentage: number;
+  };
+}
+
+export interface FactsOutput {
+  facts: PraxisFact[];
+  count: number;
+}
+
+/**
+ * Options for creating a Praxis MCP server.
+ */
+export interface PraxisMcpServerOptions<TContext = unknown> {
+  /** Name for the MCP server */
+  name?: string;
+  /** Version string */
+  version?: string;
+  /** Initial context for the engine */
+  initialContext: TContext;
+  /** Pre-configured registry (rules + constraints already registered) */
+  registry: import('../core/rules.js').PraxisRegistry<TContext>;
+  /** Initial facts */
+  initialFacts?: PraxisFact[];
+}


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server that exposes Praxis engine operations as tools for AI assistants.

## MCP Tools

| Tool | Description |
|------|-------------|
| `praxis.inspect` | List all registered rules, constraints, contracts |
| `praxis.evaluate` | Run a rule against given events, return result |
| `praxis.audit` | Run completeness audit against a manifest |
| `praxis.suggest` | Suggest rules/constraints to fill a gap |
| `praxis.facts` | Get current fact state |
| `praxis.step` | Step the engine with events, return new state |
| `praxis.contracts` | List all contracts with coverage status |

## Usage

**CLI:** `npx @plures/praxis mcp` (starts stdio transport)
**Library:** `import { createPraxisMcpServer } from '@plures/praxis/mcp'`

## Dependencies Added
- `@modelcontextprotocol/sdk` — MCP protocol implementation
- `zod` — Schema validation for tool inputs

## Tests
15 new tests, 488 total passing. TypeScript strict mode clean.