### PR TITLE
feat(chronos): project-level chronicle for development lifecycle

### DIFF
--- a/src/__tests__/chronos-project.test.ts
+++ b/src/__tests__/chronos-project.test.ts
@@ -1,0 +1,799 @@
+/**
+ * Chronos Project-Level Chronicle — Tests
+ *
+ * Comprehensive tests for:
+ * - ProjectChronicle event recording
+ * - Timeline queries (filter, range, history)
+ * - Behavioral diff (add rule, remove rule, modify contract)
+ * - Commit message generation from diffs
+ * - Hooks auto-recording
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ProjectChronicle,
+  createProjectChronicle,
+} from '../chronos/project-chronicle.js';
+import {
+  Timeline,
+  createTimeline,
+} from '../chronos/timeline.js';
+import {
+  enableProjectChronicle,
+  recordAudit,
+} from '../chronos/hooks.js';
+import {
+  diffRegistries,
+  diffContracts,
+  diffExpectations,
+  formatDelta,
+  formatCommitMessage,
+  formatReleaseNotes,
+} from '../chronos/diff.js';
+import type { RegistrySnapshot, RegistryDiff } from '../chronos/diff.js';
+import { PraxisRegistry } from '../core/rules.js';
+import { LogicEngine, createPraxisEngine } from '../core/engine.js';
+import { RuleResult, fact } from '../core/rule-result.js';
+import type { CompletenessReport } from '../core/completeness.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 1 — ProjectChronicle: event recording
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ProjectChronicle', () => {
+  let chronicle: ProjectChronicle;
+  let ts: number;
+
+  beforeEach(() => {
+    ts = 1000;
+    chronicle = createProjectChronicle({ now: () => ts++ });
+  });
+
+  it('records rule registered events', () => {
+    chronicle.recordRuleRegistered('auth/login', { description: 'Login rule' });
+    expect(chronicle.size).toBe(1);
+    const events = chronicle.getEvents();
+    expect(events[0]).toMatchObject({
+      kind: 'rule',
+      action: 'registered',
+      subject: 'auth/login',
+      timestamp: 1000,
+      metadata: { description: 'Login rule' },
+    });
+  });
+
+  it('records rule modified with diff', () => {
+    chronicle.recordRuleModified(
+      'auth/login',
+      { before: { description: 'old' }, after: { description: 'new' } },
+    );
+    const events = chronicle.getEvents();
+    expect(events[0].diff).toEqual({
+      before: { description: 'old' },
+      after: { description: 'new' },
+    });
+  });
+
+  it('records rule removed events', () => {
+    chronicle.recordRuleRemoved('auth/login');
+    expect(chronicle.getEvents()[0]).toMatchObject({
+      kind: 'rule',
+      action: 'removed',
+      subject: 'auth/login',
+    });
+  });
+
+  it('records contract events', () => {
+    chronicle.recordContractAdded('auth/login', { behavior: 'Process login' });
+    chronicle.recordContractModified(
+      'auth/login',
+      { before: 'old behavior', after: 'new behavior' },
+    );
+    expect(chronicle.size).toBe(2);
+    expect(chronicle.getEvents()[0].kind).toBe('contract');
+    expect(chronicle.getEvents()[0].action).toBe('added');
+    expect(chronicle.getEvents()[1].action).toBe('modified');
+  });
+
+  it('records expectation events', () => {
+    chronicle.recordExpectationSatisfied('all-tests-pass');
+    chronicle.recordExpectationViolated('no-type-errors');
+    expect(chronicle.size).toBe(2);
+    expect(chronicle.getEvents()[0]).toMatchObject({
+      kind: 'expectation',
+      action: 'satisfied',
+      subject: 'all-tests-pass',
+    });
+    expect(chronicle.getEvents()[1]).toMatchObject({
+      kind: 'expectation',
+      action: 'violated',
+      subject: 'no-type-errors',
+    });
+  });
+
+  it('records gate transitions with diff', () => {
+    chronicle.recordGateTransition('deploy', 'blocked', 'open');
+    const event = chronicle.getEvents()[0];
+    expect(event).toMatchObject({
+      kind: 'gate',
+      action: 'open',
+      subject: 'deploy',
+    });
+    expect(event.diff).toEqual({ before: 'blocked', after: 'open' });
+    expect(event.metadata).toMatchObject({ from: 'blocked', to: 'open' });
+  });
+
+  it('records build audit events', () => {
+    chronicle.recordBuildAudit(85, 5, { rating: 'good' });
+    const event = chronicle.getEvents()[0];
+    expect(event).toMatchObject({
+      kind: 'build',
+      action: 'audit-complete',
+      subject: 'completeness',
+    });
+    expect(event.metadata).toMatchObject({ score: 85, delta: 5, rating: 'good' });
+  });
+
+  it('records fact lifecycle events', () => {
+    chronicle.recordFactIntroduced('UserLoggedIn');
+    chronicle.recordFactDeprecated('OldFact');
+    expect(chronicle.size).toBe(2);
+    expect(chronicle.getEvents()[0]).toMatchObject({
+      kind: 'fact',
+      action: 'introduced',
+      subject: 'UserLoggedIn',
+    });
+    expect(chronicle.getEvents()[1]).toMatchObject({
+      kind: 'fact',
+      action: 'deprecated',
+      subject: 'OldFact',
+    });
+  });
+
+  it('enforces maxEvents cap', () => {
+    const small = createProjectChronicle({ maxEvents: 3, now: () => ts++ });
+    for (let i = 0; i < 5; i++) {
+      small.recordRuleRegistered(`rule-${i}`);
+    }
+    expect(small.size).toBe(3);
+    // Should have the last 3
+    const subjects = small.getEvents().map(e => e.subject);
+    expect(subjects).toEqual(['rule-2', 'rule-3', 'rule-4']);
+  });
+
+  it('clear() empties all events', () => {
+    chronicle.recordRuleRegistered('a');
+    chronicle.recordRuleRegistered('b');
+    expect(chronicle.size).toBe(2);
+    chronicle.clear();
+    expect(chronicle.size).toBe(0);
+  });
+
+  it('getEvents() returns a shallow copy', () => {
+    chronicle.recordRuleRegistered('a');
+    const events1 = chronicle.getEvents();
+    const events2 = chronicle.getEvents();
+    expect(events1).not.toBe(events2);
+    expect(events1).toEqual(events2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 2 — Timeline: queries, filtering, range, history
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Timeline', () => {
+  let chronicle: ProjectChronicle;
+  let timeline: Timeline;
+  let ts: number;
+
+  beforeEach(() => {
+    ts = 1000;
+    chronicle = createProjectChronicle({ now: () => ts++ });
+    timeline = createTimeline(chronicle);
+
+    // Seed events
+    chronicle.recordRuleRegistered('auth/login');           // ts=1000
+    chronicle.recordContractAdded('auth/login');             // ts=1001
+    chronicle.recordRuleRegistered('auth/logout');           // ts=1002
+    chronicle.recordGateTransition('deploy', 'closed', 'open'); // ts=1003
+    chronicle.recordExpectationSatisfied('tests-pass');      // ts=1004
+    chronicle.recordBuildAudit(90, 10);                      // ts=1005
+    chronicle.recordRuleRemoved('auth/logout');              // ts=1006
+  });
+
+  it('getTimeline() returns all events without filter', () => {
+    expect(timeline.getTimeline()).toHaveLength(7);
+  });
+
+  it('filters by kind', () => {
+    const rules = timeline.getTimeline({ kind: 'rule' });
+    expect(rules).toHaveLength(3); // 2 registered + 1 removed
+    expect(rules.every(e => e.kind === 'rule')).toBe(true);
+  });
+
+  it('filters by multiple kinds', () => {
+    const events = timeline.getTimeline({ kind: ['rule', 'contract'] });
+    expect(events).toHaveLength(4); // 3 rule + 1 contract
+  });
+
+  it('filters by action', () => {
+    const registered = timeline.getTimeline({ action: 'registered' });
+    expect(registered).toHaveLength(2);
+  });
+
+  it('filters by subject', () => {
+    const history = timeline.getTimeline({ subject: 'auth/login' });
+    expect(history).toHaveLength(2); // registered + contract added
+  });
+
+  it('filters by time range', () => {
+    const events = timeline.getTimeline({ since: 1002, until: 1004 });
+    expect(events).toHaveLength(3); // ts 1002, 1003, 1004
+  });
+
+  it('combines multiple filters (AND)', () => {
+    const events = timeline.getTimeline({ kind: 'rule', action: 'registered' });
+    expect(events).toHaveLength(2);
+    expect(events.every(e => e.kind === 'rule' && e.action === 'registered')).toBe(true);
+  });
+
+  it('getEventsSince() returns events from timestamp', () => {
+    const events = timeline.getEventsSince(1005);
+    expect(events).toHaveLength(2); // ts 1005, 1006
+  });
+
+  it('getHistory() returns all events for a subject', () => {
+    const history = timeline.getHistory('auth/login');
+    expect(history).toHaveLength(2);
+    expect(history[0].action).toBe('registered');
+    expect(history[1].action).toBe('added');
+  });
+
+  describe('getDelta()', () => {
+    it('computes behavioral delta for a time range', () => {
+      const delta = timeline.getDelta(1000, 1006);
+      expect(delta.from).toBe(1000);
+      expect(delta.to).toBe(1006);
+      expect(delta.events).toHaveLength(7);
+    });
+
+    it('identifies added subjects', () => {
+      // auth/login registered, auth/logout registered then removed
+      const delta = timeline.getDelta(1000, 1006);
+      // auth/login is added (registered at 1000)
+      expect(delta.added).toContain('auth/login');
+    });
+
+    it('identifies removed subjects', () => {
+      const delta = timeline.getDelta(1000, 1006);
+      // auth/logout was registered then removed — net effect is removed
+      expect(delta.removed).toContain('auth/logout');
+    });
+
+    it('provides summary counts by kind', () => {
+      const delta = timeline.getDelta(1000, 1006);
+      expect(delta.summary.rule).toBe(3);
+      expect(delta.summary.contract).toBe(1);
+      expect(delta.summary.gate).toBe(1);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 3 — Behavioral Diff
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Behavioral Diff', () => {
+  describe('diffRegistries', () => {
+    it('detects added rules', () => {
+      const before: RegistrySnapshot = {
+        rules: [{ id: 'a', description: 'Rule A', impl: () => RuleResult.noop() }],
+        constraints: [],
+      };
+      const after: RegistrySnapshot = {
+        rules: [
+          { id: 'a', description: 'Rule A', impl: () => RuleResult.noop() },
+          { id: 'b', description: 'Rule B', impl: () => RuleResult.noop() },
+        ],
+        constraints: [],
+      };
+      const diff = diffRegistries(before, after);
+      expect(diff.rulesAdded).toEqual(['b']);
+      expect(diff.rulesRemoved).toEqual([]);
+    });
+
+    it('detects removed rules', () => {
+      const before: RegistrySnapshot = {
+        rules: [
+          { id: 'a', description: 'Rule A', impl: () => RuleResult.noop() },
+          { id: 'b', description: 'Rule B', impl: () => RuleResult.noop() },
+        ],
+        constraints: [],
+      };
+      const after: RegistrySnapshot = {
+        rules: [{ id: 'a', description: 'Rule A', impl: () => RuleResult.noop() }],
+        constraints: [],
+      };
+      const diff = diffRegistries(before, after);
+      expect(diff.rulesRemoved).toEqual(['b']);
+      expect(diff.rulesAdded).toEqual([]);
+    });
+
+    it('detects modified rules (description changed)', () => {
+      const before: RegistrySnapshot = {
+        rules: [{ id: 'a', description: 'Rule A v1', impl: () => RuleResult.noop() }],
+        constraints: [],
+      };
+      const after: RegistrySnapshot = {
+        rules: [{ id: 'a', description: 'Rule A v2', impl: () => RuleResult.noop() }],
+        constraints: [],
+      };
+      const diff = diffRegistries(before, after);
+      expect(diff.rulesModified).toEqual(['a']);
+    });
+
+    it('handles Map inputs', () => {
+      const before: RegistrySnapshot = {
+        rules: new Map([['a', { id: 'a', description: 'A', impl: () => RuleResult.noop() }]]),
+        constraints: new Map(),
+      };
+      const after: RegistrySnapshot = {
+        rules: new Map([
+          ['a', { id: 'a', description: 'A', impl: () => RuleResult.noop() }],
+          ['b', { id: 'b', description: 'B', impl: () => RuleResult.noop() }],
+        ]),
+        constraints: new Map(),
+      };
+      const diff = diffRegistries(before, after);
+      expect(diff.rulesAdded).toEqual(['b']);
+    });
+
+    it('detects constraint changes', () => {
+      const before: RegistrySnapshot = {
+        rules: [],
+        constraints: [{ id: 'c1', description: 'Constraint 1', impl: () => true }],
+      };
+      const after: RegistrySnapshot = {
+        rules: [],
+        constraints: [{ id: 'c2', description: 'Constraint 2', impl: () => true }],
+      };
+      const diff = diffRegistries(before, after);
+      expect(diff.constraintsAdded).toEqual(['c2']);
+      expect(diff.constraintsRemoved).toEqual(['c1']);
+    });
+  });
+
+  describe('diffContracts', () => {
+    it('detects newly added contracts', () => {
+      const before = { coverage: { 'auth/login': false, 'auth/logout': true } };
+      const after = { coverage: { 'auth/login': true, 'auth/logout': true } };
+      const diff = diffContracts(before, after);
+      expect(diff.contractsAdded).toEqual(['auth/login']);
+      expect(diff.contractsRemoved).toEqual([]);
+    });
+
+    it('detects removed contracts', () => {
+      const before = { coverage: new Map([['a', true]]) };
+      const after = { coverage: new Map([['a', false]]) };
+      const diff = diffContracts(before, after);
+      expect(diff.contractsRemoved).toEqual(['a']);
+    });
+
+    it('computes coverage ratios', () => {
+      const before = { coverage: { a: true, b: false } };
+      const after = { coverage: { a: true, b: true } };
+      const diff = diffContracts(before, after);
+      expect(diff.coverageBefore).toBe(0.5);
+      expect(diff.coverageAfter).toBe(1);
+    });
+  });
+
+  describe('diffExpectations', () => {
+    it('detects newly satisfied expectations', () => {
+      const before = { expectations: { 'tests-pass': false, 'lint-clean': true } };
+      const after = { expectations: { 'tests-pass': true, 'lint-clean': true } };
+      const diff = diffExpectations(before, after);
+      expect(diff.newlySatisfied).toEqual(['tests-pass']);
+      expect(diff.newlyViolated).toEqual([]);
+      expect(diff.unchanged).toContain('lint-clean');
+    });
+
+    it('detects newly violated expectations', () => {
+      const before = { expectations: new Map([['a', true]]) };
+      const after = { expectations: new Map([['a', false]]) };
+      const diff = diffExpectations(before, after);
+      expect(diff.newlyViolated).toEqual(['a']);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 4 — Commit message generation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Commit Message Generation', () => {
+  it('generates feat commit for added rules', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: ['auth/login'],
+      rulesRemoved: [],
+      rulesModified: [],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const msg = formatCommitMessage(diff);
+    expect(msg).toContain('feat(auth)');
+    expect(msg).toContain('auth/login');
+  });
+
+  it('generates refactor commit for removed rules', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: [],
+      rulesRemoved: ['auth/legacy'],
+      rulesModified: [],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const msg = formatCommitMessage(diff);
+    expect(msg).toContain('refactor(auth)');
+    expect(msg).toContain('remove');
+  });
+
+  it('generates refactor commit for modified rules', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: [],
+      rulesRemoved: [],
+      rulesModified: ['auth/login'],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const msg = formatCommitMessage(diff);
+    expect(msg).toContain('refactor(auth)');
+    expect(msg).toContain('update');
+  });
+
+  it('generates chore commit for no changes', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: [],
+      rulesRemoved: [],
+      rulesModified: [],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const msg = formatCommitMessage(diff);
+    expect(msg).toContain('chore');
+  });
+
+  it('includes body with details', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: ['auth/login', 'auth/logout'],
+      rulesRemoved: [],
+      rulesModified: [],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const msg = formatCommitMessage(diff);
+    expect(msg).toContain('Rules added: auth/login, auth/logout');
+  });
+});
+
+describe('formatDelta', () => {
+  it('formats a human-readable delta', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: ['auth/login'],
+      rulesRemoved: ['auth/legacy'],
+      rulesModified: [],
+      constraintsAdded: ['max-retries'],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    const text = formatDelta(diff);
+    expect(text).toContain('+ Rules added: auth/login');
+    expect(text).toContain('- Rules removed: auth/legacy');
+    expect(text).toContain('+ Constraints added: max-retries');
+  });
+
+  it('returns "No behavioral changes." for empty diff', () => {
+    const diff: RegistryDiff = {
+      rulesAdded: [],
+      rulesRemoved: [],
+      rulesModified: [],
+      constraintsAdded: [],
+      constraintsRemoved: [],
+      constraintsModified: [],
+    };
+    expect(formatDelta(diff)).toBe('No behavioral changes.');
+  });
+});
+
+describe('formatReleaseNotes', () => {
+  it('aggregates multiple diffs into release notes', () => {
+    const diffs: RegistryDiff[] = [
+      {
+        rulesAdded: ['auth/login'],
+        rulesRemoved: [],
+        rulesModified: [],
+        constraintsAdded: [],
+        constraintsRemoved: [],
+        constraintsModified: [],
+      },
+      {
+        rulesAdded: ['data/sync'],
+        rulesRemoved: ['auth/legacy'],
+        rulesModified: ['auth/login'],
+        constraintsAdded: [],
+        constraintsRemoved: [],
+        constraintsModified: [],
+      },
+    ];
+    const notes = formatReleaseNotes(diffs);
+    expect(notes).toContain('## Release Notes');
+    expect(notes).toContain('### Added');
+    expect(notes).toContain('- auth/login');
+    expect(notes).toContain('- data/sync');
+    expect(notes).toContain('### Changed');
+    expect(notes).toContain('### Removed');
+    expect(notes).toContain('- auth/legacy');
+  });
+
+  it('returns message for empty diffs', () => {
+    const notes = formatReleaseNotes([]);
+    expect(notes).toBe('No behavioral changes in this release.');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 5 — Hooks: auto-recording
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Hooks (enableProjectChronicle)', () => {
+  let registry: PraxisRegistry;
+  let engine: LogicEngine;
+
+  beforeEach(() => {
+    registry = new PraxisRegistry({ compliance: { enabled: false } });
+    engine = createPraxisEngine({ initialContext: {}, registry });
+  });
+
+  it('auto-records rule registration', () => {
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    registry.registerRule({
+      id: 'test/rule',
+      description: 'Test rule',
+      impl: () => RuleResult.noop(),
+    });
+
+    expect(chronicle.size).toBeGreaterThan(0);
+    const events = chronicle.getEvents();
+    const ruleEvent = events.find(e => e.kind === 'rule' && e.action === 'registered');
+    expect(ruleEvent).toBeDefined();
+    expect(ruleEvent!.subject).toBe('test/rule');
+
+    disconnect();
+  });
+
+  it('auto-records rule with contract', () => {
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    registry.registerRule({
+      id: 'test/contracted',
+      description: 'Contracted rule',
+      contract: {
+        ruleId: 'test/contracted',
+        behavior: 'Does stuff',
+        examples: [{ given: 'x', when: 'y', then: 'z' }],
+        invariants: ['always works'],
+      },
+      impl: () => RuleResult.noop(),
+    });
+
+    const events = chronicle.getEvents();
+    const contractEvent = events.find(e => e.kind === 'contract' && e.action === 'added');
+    expect(contractEvent).toBeDefined();
+    expect(contractEvent!.subject).toBe('test/contracted');
+    expect(contractEvent!.metadata).toMatchObject({
+      behavior: 'Does stuff',
+      examplesCount: 1,
+      invariantsCount: 1,
+    });
+
+    disconnect();
+  });
+
+  it('auto-records engine step results', () => {
+    // Register a rule first (before hooking, to avoid double-recording confusion)
+    registry.registerRule({
+      id: 'test/emit',
+      description: 'Emit a fact',
+      impl: () => RuleResult.emit([fact('test.fact', { value: 42 })]),
+    });
+
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    engine.step([{ tag: 'test.event', payload: {} }]);
+
+    const events = chronicle.getEvents();
+    const stepEvent = events.find(e => e.kind === 'build' && e.action === 'step-complete');
+    expect(stepEvent).toBeDefined();
+    expect(stepEvent!.metadata).toMatchObject({
+      eventsProcessed: 1,
+      eventTags: ['test.event'],
+    });
+
+    disconnect();
+  });
+
+  it('auto-records constraint violations from step', () => {
+    registry.registerRule({
+      id: 'test/rule',
+      description: 'noop',
+      impl: () => RuleResult.noop(),
+    });
+    registry.registerConstraint({
+      id: 'test/constraint',
+      description: 'Always fails',
+      impl: () => 'This always fails',
+    });
+
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    engine.step([{ tag: 'x', payload: {} }]);
+
+    const events = chronicle.getEvents();
+    const violationEvent = events.find(
+      e => e.kind === 'expectation' && e.action === 'violated',
+    );
+    expect(violationEvent).toBeDefined();
+    expect(violationEvent!.subject).toBe('test/constraint');
+
+    disconnect();
+  });
+
+  it('auto-records checkConstraints results', () => {
+    registry.registerConstraint({
+      id: 'test/always-ok',
+      description: 'Always passes',
+      impl: () => true,
+    });
+
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    engine.checkConstraints();
+
+    const events = chronicle.getEvents();
+    const checkEvent = events.find(e => e.action === 'constraints-checked');
+    expect(checkEvent).toBeDefined();
+    expect(checkEvent!.metadata).toMatchObject({ violations: 0 });
+
+    disconnect();
+  });
+
+  it('disconnect() restores original methods', () => {
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+
+    registry.registerRule({
+      id: 'pre-disconnect',
+      description: 'before disconnect',
+      impl: () => RuleResult.noop(),
+    });
+
+    const countBefore = chronicle.size;
+    expect(countBefore).toBeGreaterThan(0);
+
+    disconnect();
+
+    // After disconnect, new registrations should NOT be recorded
+    registry.registerRule({
+      id: 'post-disconnect',
+      description: 'after disconnect',
+      impl: () => RuleResult.noop(),
+    });
+
+    expect(chronicle.size).toBe(countBefore);
+  });
+
+  it('respects recordSteps: false', () => {
+    const { chronicle, disconnect } = enableProjectChronicle(registry, engine, {
+      recordSteps: false,
+    });
+
+    registry.registerRule({
+      id: 'r1',
+      description: 'r1',
+      impl: () => RuleResult.noop(),
+    });
+
+    engine.step([{ tag: 'x', payload: {} }]);
+
+    const stepEvents = chronicle.getEvents().filter(e => e.action === 'step-complete');
+    expect(stepEvents).toHaveLength(0);
+
+    // But rule registration should still be recorded
+    const ruleEvents = chronicle.getEvents().filter(e => e.kind === 'rule');
+    expect(ruleEvents.length).toBeGreaterThan(0);
+
+    disconnect();
+  });
+});
+
+describe('recordAudit', () => {
+  it('records a completeness audit', () => {
+    const chronicle = createProjectChronicle();
+    const report: CompletenessReport = {
+      score: 85,
+      rating: 'good',
+      rules: { total: 10, covered: 8, uncovered: [] },
+      constraints: { total: 5, covered: 5, uncovered: [] },
+      contracts: { total: 8, withContracts: 6, missing: ['a', 'b'] },
+      context: { total: 4, covered: 4, missing: [] },
+      events: { total: 6, covered: 5, missing: [] },
+    };
+
+    recordAudit(chronicle, report, 80);
+
+    expect(chronicle.size).toBe(1);
+    const event = chronicle.getEvents()[0];
+    expect(event).toMatchObject({
+      kind: 'build',
+      action: 'audit-complete',
+      subject: 'completeness',
+    });
+    expect(event.metadata).toMatchObject({
+      score: 85,
+      delta: 5,
+      rating: 'good',
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// § 6 — Integration: end-to-end scenario
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('End-to-end: chronicle + timeline + diff', () => {
+  it('chronicles rule lifecycle and queries it', () => {
+    let ts = 1000;
+    const chronicle = createProjectChronicle({ now: () => ts++ });
+    const timeline = createTimeline(chronicle);
+
+    // Simulate development lifecycle
+    chronicle.recordRuleRegistered('auth/login');
+    chronicle.recordContractAdded('auth/login');
+    chronicle.recordRuleRegistered('auth/logout');
+    chronicle.recordRuleModified('auth/login', {
+      before: { description: 'v1' },
+      after: { description: 'v2' },
+    });
+    chronicle.recordBuildAudit(75, 0);
+    chronicle.recordGateTransition('release', 'closed', 'blocked');
+    chronicle.recordExpectationSatisfied('tests-pass');
+    chronicle.recordGateTransition('release', 'blocked', 'open');
+    chronicle.recordBuildAudit(90, 15);
+
+    // Query timeline
+    const ruleHistory = timeline.getHistory('auth/login');
+    expect(ruleHistory).toHaveLength(3); // registered, contract added, modified
+
+    // Get delta
+    const delta = timeline.getDelta(1000, 1010);
+    expect(delta.added).toContain('auth/login');
+    expect(delta.added).toContain('auth/logout');
+    expect(delta.modified).toContain('auth/login');
+
+    // Check build events
+    const builds = timeline.getTimeline({ kind: 'build' });
+    expect(builds).toHaveLength(2);
+
+    // Check gate transitions
+    const gates = timeline.getTimeline({ kind: 'gate' });
+    expect(gates).toHaveLength(2);
+    expect(gates[0].action).toBe('blocked');
+    expect(gates[1].action).toBe('open');
+  });
+});

--- a/src/chronos/diff.ts
+++ b/src/chronos/diff.ts
@@ -1,0 +1,336 @@
+/**
+ * Behavioral Diff Engine
+ *
+ * Compares registry snapshots, contract coverage, and expectation status
+ * to produce human-readable deltas and conventional commit messages.
+ *
+ * This is the foundation for "commit from state" — describing WHAT changed
+ * in behavioral terms rather than file terms.
+ */
+
+import type { RuleDescriptor, ConstraintDescriptor } from '../core/rules.js';
+import type { PraxisDiff } from '../project/types.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Snapshot of a registry's state (used for before/after comparison). */
+export interface RegistrySnapshot {
+  rules: Map<string, RuleDescriptor> | Array<RuleDescriptor>;
+  constraints: Map<string, ConstraintDescriptor> | Array<ConstraintDescriptor>;
+}
+
+/** Diff result for registries. */
+export interface RegistryDiff {
+  rulesAdded: string[];
+  rulesRemoved: string[];
+  rulesModified: string[];
+  constraintsAdded: string[];
+  constraintsRemoved: string[];
+  constraintsModified: string[];
+}
+
+/** Contract coverage snapshot. */
+export interface ContractCoverage {
+  /** rule id → has contract */
+  coverage: Map<string, boolean> | Record<string, boolean>;
+}
+
+/** Diff result for contract coverage. */
+export interface ContractDiff {
+  contractsAdded: string[];
+  contractsRemoved: string[];
+  coverageBefore: number;
+  coverageAfter: number;
+}
+
+/** Expectation satisfaction snapshot. */
+export interface ExpectationSnapshot {
+  /** expectation name → satisfied */
+  expectations: Map<string, boolean> | Record<string, boolean>;
+}
+
+/** Diff result for expectations. */
+export interface ExpectationDiff {
+  newlySatisfied: string[];
+  newlyViolated: string[];
+  unchanged: string[];
+}
+
+/** Full behavioral diff combining all dimensions. */
+export interface FullBehavioralDiff {
+  registry: RegistryDiff;
+  contracts: ContractDiff;
+  expectations: ExpectationDiff;
+}
+
+// ─── Registry Diff ──────────────────────────────────────────────────────────
+
+/**
+ * Compare two registry snapshots.
+ *
+ * Detects rules/constraints that were added, removed, or modified
+ * (description or contract changed).
+ */
+export function diffRegistries(before: RegistrySnapshot, after: RegistrySnapshot): RegistryDiff {
+  const beforeRules = toIdMap(before.rules);
+  const afterRules = toIdMap(after.rules);
+  const beforeConstraints = toIdMap(before.constraints);
+  const afterConstraints = toIdMap(after.constraints);
+
+  return {
+    rulesAdded: setDiff(afterRules, beforeRules),
+    rulesRemoved: setDiff(beforeRules, afterRules),
+    rulesModified: findModified(beforeRules, afterRules),
+    constraintsAdded: setDiff(afterConstraints, beforeConstraints),
+    constraintsRemoved: setDiff(beforeConstraints, afterConstraints),
+    constraintsModified: findModified(beforeConstraints, afterConstraints),
+  };
+}
+
+// ─── Contract Diff ──────────────────────────────────────────────────────────
+
+/**
+ * Compare contract coverage between two snapshots.
+ */
+export function diffContracts(before: ContractCoverage, after: ContractCoverage): ContractDiff {
+  const beforeMap = toRecord(before.coverage);
+  const afterMap = toRecord(after.coverage);
+
+  const contractsAdded: string[] = [];
+  const contractsRemoved: string[] = [];
+
+  // Check for newly added contracts
+  for (const [id, has] of Object.entries(afterMap)) {
+    if (has && !beforeMap[id]) {
+      contractsAdded.push(id);
+    }
+  }
+
+  // Check for removed contracts
+  for (const [id, had] of Object.entries(beforeMap)) {
+    if (had && !afterMap[id]) {
+      contractsRemoved.push(id);
+    }
+  }
+
+  const countTrue = (r: Record<string, boolean>) =>
+    Object.values(r).filter(Boolean).length;
+  const totalBefore = Object.keys(beforeMap).length;
+  const totalAfter = Object.keys(afterMap).length;
+
+  return {
+    contractsAdded,
+    contractsRemoved,
+    coverageBefore: totalBefore > 0 ? countTrue(beforeMap) / totalBefore : 0,
+    coverageAfter: totalAfter > 0 ? countTrue(afterMap) / totalAfter : 0,
+  };
+}
+
+// ─── Expectation Diff ───────────────────────────────────────────────────────
+
+/**
+ * Compare expectation satisfaction between two snapshots.
+ */
+export function diffExpectations(
+  before: ExpectationSnapshot,
+  after: ExpectationSnapshot,
+): ExpectationDiff {
+  const beforeMap = toRecord(before.expectations);
+  const afterMap = toRecord(after.expectations);
+  const allKeys = new Set([...Object.keys(beforeMap), ...Object.keys(afterMap)]);
+
+  const newlySatisfied: string[] = [];
+  const newlyViolated: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const key of allKeys) {
+    const was = beforeMap[key] ?? false;
+    const is = afterMap[key] ?? false;
+    if (!was && is) {
+      newlySatisfied.push(key);
+    } else if (was && !is) {
+      newlyViolated.push(key);
+    } else {
+      unchanged.push(key);
+    }
+  }
+
+  return { newlySatisfied, newlyViolated, unchanged };
+}
+
+// ─── Formatting ─────────────────────────────────────────────────────────────
+
+/**
+ * Format a RegistryDiff as a human-readable delta string.
+ */
+export function formatDelta(diff: RegistryDiff): string {
+  const lines: string[] = [];
+
+  if (diff.rulesAdded.length > 0)
+    lines.push(`+ Rules added: ${diff.rulesAdded.join(', ')}`);
+  if (diff.rulesRemoved.length > 0)
+    lines.push(`- Rules removed: ${diff.rulesRemoved.join(', ')}`);
+  if (diff.rulesModified.length > 0)
+    lines.push(`~ Rules modified: ${diff.rulesModified.join(', ')}`);
+  if (diff.constraintsAdded.length > 0)
+    lines.push(`+ Constraints added: ${diff.constraintsAdded.join(', ')}`);
+  if (diff.constraintsRemoved.length > 0)
+    lines.push(`- Constraints removed: ${diff.constraintsRemoved.join(', ')}`);
+  if (diff.constraintsModified.length > 0)
+    lines.push(`~ Constraints modified: ${diff.constraintsModified.join(', ')}`);
+
+  return lines.length > 0 ? lines.join('\n') : 'No behavioral changes.';
+}
+
+/**
+ * Generate a conventional commit message from a registry diff.
+ *
+ * Uses the same logic as `commitFromState` in `project/` but works
+ * directly from a RegistryDiff.
+ */
+export function formatCommitMessage(diff: RegistryDiff): string {
+  const praxisDiff: PraxisDiff = {
+    rulesAdded: diff.rulesAdded,
+    rulesRemoved: diff.rulesRemoved,
+    rulesModified: diff.rulesModified,
+    contractsAdded: [],
+    contractsRemoved: [],
+    expectationsAdded: diff.constraintsAdded,
+    expectationsRemoved: diff.constraintsRemoved,
+    gateChanges: [],
+  };
+
+  return commitFromDiff(praxisDiff);
+}
+
+/**
+ * Aggregate multiple diffs into release notes.
+ */
+export function formatReleaseNotes(diffs: RegistryDiff[]): string {
+  const sections: string[] = [];
+  const allAdded: string[] = [];
+  const allRemoved: string[] = [];
+  const allModified: string[] = [];
+
+  for (const diff of diffs) {
+    allAdded.push(...diff.rulesAdded, ...diff.constraintsAdded);
+    allRemoved.push(...diff.rulesRemoved, ...diff.constraintsRemoved);
+    allModified.push(...diff.rulesModified, ...diff.constraintsModified);
+  }
+
+  // Deduplicate
+  const added = [...new Set(allAdded)];
+  const removed = [...new Set(allRemoved)];
+  const modified = [...new Set(allModified)];
+
+  if (added.length > 0) {
+    sections.push(`### Added\n${added.map(id => `- ${id}`).join('\n')}`);
+  }
+  if (modified.length > 0) {
+    sections.push(`### Changed\n${modified.map(id => `- ${id}`).join('\n')}`);
+  }
+  if (removed.length > 0) {
+    sections.push(`### Removed\n${removed.map(id => `- ${id}`).join('\n')}`);
+  }
+
+  if (sections.length === 0) return 'No behavioral changes in this release.';
+  return `## Release Notes\n\n${sections.join('\n\n')}`;
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────────
+
+function toIdMap(
+  input: Map<string, { id: string; description: string }> | Array<{ id: string; description: string }>,
+): Map<string, { id: string; description: string }> {
+  if (input instanceof Map) return input;
+  const map = new Map<string, { id: string; description: string }>();
+  for (const item of input) map.set(item.id, item);
+  return map;
+}
+
+function setDiff(a: Map<string, unknown>, b: Map<string, unknown>): string[] {
+  const result: string[] = [];
+  for (const key of a.keys()) {
+    if (!b.has(key)) result.push(key);
+  }
+  return result;
+}
+
+function findModified(
+  before: Map<string, { id: string; description: string }>,
+  after: Map<string, { id: string; description: string }>,
+): string[] {
+  const result: string[] = [];
+  for (const [key, beforeVal] of before) {
+    const afterVal = after.get(key);
+    if (afterVal && beforeVal.description !== afterVal.description) {
+      result.push(key);
+    }
+  }
+  return result;
+}
+
+function toRecord(input: Map<string, boolean> | Record<string, boolean>): Record<string, boolean> {
+  if (input instanceof Map) {
+    const result: Record<string, boolean> = {};
+    for (const [k, v] of input) result[k] = v;
+    return result;
+  }
+  return input;
+}
+
+// ── Inline commit message generation (mirrors project/project.ts logic) ──
+
+function commitFromDiff(diff: PraxisDiff): string {
+  const parts: string[] = [];
+  const bodyParts: string[] = [];
+
+  const totalAdded = diff.rulesAdded.length + diff.contractsAdded.length + diff.expectationsAdded.length;
+  const totalRemoved = diff.rulesRemoved.length + diff.contractsRemoved.length + diff.expectationsRemoved.length;
+  const totalModified = diff.rulesModified.length;
+
+  if (totalAdded > 0 && totalRemoved === 0 && totalModified === 0) {
+    if (diff.rulesAdded.length > 0) {
+      const scope = inferScope(diff.rulesAdded);
+      parts.push(`feat(${scope}): add ${fmtIds(diff.rulesAdded)}`);
+    } else if (diff.contractsAdded.length > 0) {
+      parts.push(`feat(contracts): add contracts for ${fmtIds(diff.contractsAdded)}`);
+    } else {
+      parts.push(`feat(expectations): add ${fmtIds(diff.expectationsAdded)}`);
+    }
+  } else if (totalRemoved > 0 && totalAdded === 0) {
+    if (diff.rulesRemoved.length > 0) {
+      const scope = inferScope(diff.rulesRemoved);
+      parts.push(`refactor(${scope}): remove ${fmtIds(diff.rulesRemoved)}`);
+    } else {
+      parts.push(`refactor: remove ${totalRemoved} item(s)`);
+    }
+  } else if (totalModified > 0) {
+    const scope = inferScope(diff.rulesModified);
+    parts.push(`refactor(${scope}): update ${fmtIds(diff.rulesModified)}`);
+  } else {
+    parts.push('chore: behavioral state update');
+  }
+
+  if (diff.rulesAdded.length > 0) bodyParts.push(`Rules added: ${diff.rulesAdded.join(', ')}`);
+  if (diff.rulesRemoved.length > 0) bodyParts.push(`Rules removed: ${diff.rulesRemoved.join(', ')}`);
+  if (diff.rulesModified.length > 0) bodyParts.push(`Rules modified: ${diff.rulesModified.join(', ')}`);
+
+  const subject = parts[0] || 'chore: update';
+  return bodyParts.length > 0 ? `${subject}\n\n${bodyParts.join('\n')}` : subject;
+}
+
+function inferScope(ids: string[]): string {
+  if (ids.length === 0) return 'rules';
+  const prefixes = ids.map(id => {
+    const slash = id.indexOf('/');
+    return slash > 0 ? id.slice(0, slash) : id;
+  });
+  const unique = new Set(prefixes);
+  return unique.size === 1 ? prefixes[0] : 'rules';
+}
+
+function fmtIds(ids: string[]): string {
+  if (ids.length <= 3) return ids.join(', ');
+  return `${ids.slice(0, 2).join(', ')} (+${ids.length - 2} more)`;
+}

--- a/src/chronos/hooks.ts
+++ b/src/chronos/hooks.ts
@@ -1,0 +1,227 @@
+/**
+ * Auto-Recording Hooks — wire ProjectChronicle into PraxisRegistry & LogicEngine
+ *
+ * Opt-in: call `enableProjectChronicle(registry, engine)` to start recording.
+ * The hooks use Proxy wrapping to intercept method calls without modifying
+ * the original classes.
+ */
+
+import type { PraxisRegistry, RuleDescriptor, PraxisModule } from '../core/rules.js';
+import type { LogicEngine } from '../core/engine.js';
+import type { PraxisEvent, PraxisStepResult, PraxisDiagnostics } from '../core/protocol.js';
+import { ProjectChronicle, createProjectChronicle } from './project-chronicle.js';
+import type { CompletenessReport } from '../core/completeness.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Handle returned by enableProjectChronicle for cleanup. */
+export interface ChronicleHandle {
+  /** The underlying chronicle being written to. */
+  chronicle: ProjectChronicle;
+  /** Disconnect all hooks (restores original methods). */
+  disconnect: () => void;
+}
+
+/** Options for enabling project chronicle hooks. */
+export interface EnableChronicleOptions {
+  /** Provide an existing chronicle (otherwise a new one is created). */
+  chronicle?: ProjectChronicle;
+  /** Record engine step results (fact production/retraction). Default: true. */
+  recordSteps?: boolean;
+  /** Record constraint check results. Default: true. */
+  recordConstraints?: boolean;
+}
+
+// ─── Hook Implementation ────────────────────────────────────────────────────
+
+/**
+ * Enable project-level chronicle recording.
+ *
+ * Wraps registry's `registerRule`, `registerModule` and engine's `step`,
+ * `checkConstraints` methods to automatically record events.
+ *
+ * @returns A handle with the chronicle and a `disconnect()` to undo all hooks.
+ *
+ * @example
+ * ```ts
+ * const { chronicle, disconnect } = enableProjectChronicle(registry, engine);
+ * registry.registerRule(myRule); // auto-recorded
+ * engine.step(events);          // step results auto-recorded
+ * console.log(chronicle.size);  // number of events recorded
+ * disconnect();                 // stop recording
+ * ```
+ */
+export function enableProjectChronicle<TContext = unknown>(
+  registry: PraxisRegistry<TContext>,
+  engine: LogicEngine<TContext>,
+  options: EnableChronicleOptions = {},
+): ChronicleHandle {
+  const chronicle = options.chronicle ?? createProjectChronicle();
+  const recordSteps = options.recordSteps ?? true;
+  const recordConstraints = options.recordConstraints ?? true;
+
+  // Keep originals for cleanup
+  const origRegisterRule = registry.registerRule.bind(registry);
+  const origRegisterModule = registry.registerModule.bind(registry);
+  const origStep = engine.step.bind(engine);
+  const origCheckConstraints = engine.checkConstraints.bind(engine);
+
+  // ── Hook: registerRule ──────────────────────────────────────────────────
+
+  registry.registerRule = function hookedRegisterRule(
+    descriptor: RuleDescriptor<TContext>,
+  ): void {
+    origRegisterRule(descriptor);
+    chronicle.recordRuleRegistered(descriptor.id, {
+      description: descriptor.description,
+      hasContract: !!descriptor.contract,
+      eventTypes: descriptor.eventTypes,
+    });
+    if (descriptor.contract) {
+      chronicle.recordContractAdded(descriptor.id, {
+        behavior: descriptor.contract.behavior,
+        examplesCount: descriptor.contract.examples?.length ?? 0,
+        invariantsCount: descriptor.contract.invariants?.length ?? 0,
+      });
+    }
+  };
+
+  // ── Hook: registerModule ────────────────────────────────────────────────
+
+  registry.registerModule = function hookedRegisterModule(
+    module: PraxisModule<TContext>,
+  ): void {
+    // Call original (which calls registerRule/registerConstraint internally)
+    // But we need to unhook registerRule temporarily to avoid double recording.
+    // Instead, record the module-level event and let the rules record individually.
+    origRegisterModule(module);
+
+    // Record a module-level event for each rule that was part of this module
+    for (const rule of module.rules) {
+      chronicle.recordRuleRegistered(rule.id, {
+        description: rule.description,
+        hasContract: !!rule.contract,
+        eventTypes: rule.eventTypes,
+        registeredVia: 'module',
+      });
+      if (rule.contract) {
+        chronicle.recordContractAdded(rule.id, {
+          behavior: rule.contract.behavior,
+          examplesCount: rule.contract.examples?.length ?? 0,
+          invariantsCount: rule.contract.invariants?.length ?? 0,
+        });
+      }
+    }
+  };
+
+  // ── Hook: engine.step ───────────────────────────────────────────────────
+
+  if (recordSteps) {
+    engine.step = function hookedStep(events: PraxisEvent[]): PraxisStepResult {
+      const result = origStep(events);
+
+      // Record each fact that was produced
+      const factTags = new Set<string>();
+      for (const fact of result.state.facts) {
+        factTags.add(fact.tag);
+      }
+
+      // Record step event
+      chronicle.record({
+        kind: 'build',
+        action: 'step-complete',
+        subject: 'engine',
+        metadata: {
+          eventsProcessed: events.length,
+          eventTags: events.map(e => e.tag),
+          factsAfter: result.state.facts.length,
+          diagnosticsCount: result.diagnostics.length,
+        },
+      });
+
+      // Record any rule errors or constraint violations
+      for (const diag of result.diagnostics) {
+        if (diag.kind === 'constraint-violation') {
+          chronicle.record({
+            kind: 'expectation',
+            action: 'violated',
+            subject: extractSubjectFromDiag(diag),
+            metadata: { message: diag.message, data: diag.data },
+          });
+        }
+      }
+
+      return result;
+    };
+  }
+
+  // ── Hook: engine.checkConstraints ───────────────────────────────────────
+
+  if (recordConstraints) {
+    engine.checkConstraints = function hookedCheckConstraints(): PraxisDiagnostics[] {
+      const diagnostics = origCheckConstraints();
+
+      chronicle.record({
+        kind: 'build',
+        action: 'constraints-checked',
+        subject: 'engine',
+        metadata: {
+          violations: diagnostics.length,
+        },
+      });
+
+      for (const diag of diagnostics) {
+        chronicle.record({
+          kind: 'expectation',
+          action: 'violated',
+          subject: extractSubjectFromDiag(diag),
+          metadata: { message: diag.message },
+        });
+      }
+
+      return diagnostics;
+    };
+  }
+
+  // ── Disconnect ──────────────────────────────────────────────────────────
+
+  function disconnect(): void {
+    registry.registerRule = origRegisterRule;
+    registry.registerModule = origRegisterModule;
+    engine.step = origStep;
+    engine.checkConstraints = origCheckConstraints;
+  }
+
+  return { chronicle, disconnect };
+}
+
+/**
+ * Record a completeness audit result into the chronicle.
+ *
+ * Standalone utility — call after `auditCompleteness()`.
+ */
+export function recordAudit(
+  chronicle: ProjectChronicle,
+  report: CompletenessReport,
+  previousScore?: number,
+): void {
+  const delta = previousScore != null ? report.score - previousScore : 0;
+  chronicle.recordBuildAudit(report.score, delta, {
+    rating: report.rating,
+    rulesCovered: report.rules.covered,
+    rulesTotal: report.rules.total,
+    constraintsCovered: report.constraints.covered,
+    constraintsTotal: report.constraints.total,
+    contractsCovered: report.contracts.withContracts,
+    contractsTotal: report.contracts.total,
+  });
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+
+function extractSubjectFromDiag(diag: PraxisDiagnostics): string {
+  const data = diag.data as Record<string, unknown> | undefined;
+  if (data?.constraintId && typeof data.constraintId === 'string') return data.constraintId;
+  if (data?.ruleId && typeof data.ruleId === 'string') return data.ruleId;
+  return 'unknown';
+}

--- a/src/chronos/index.ts
+++ b/src/chronos/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Chronos — Project-Level Chronicle
+ *
+ * Records and queries the development lifecycle of a Praxis application:
+ * rule registrations, contract changes, gate transitions, build audits, etc.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   createProjectChronicle,
+ *   createTimeline,
+ *   enableProjectChronicle,
+ *   diffRegistries,
+ * } from '@plures/praxis';
+ *
+ * // Manual recording
+ * const chronicle = createProjectChronicle();
+ * chronicle.recordRuleRegistered('auth/login', { description: 'Login rule' });
+ *
+ * // Auto-recording via hooks
+ * const { chronicle: autoChronicle, disconnect } = enableProjectChronicle(registry, engine);
+ * registry.registerRule(myRule); // automatically recorded
+ *
+ * // Querying
+ * const timeline = createTimeline(autoChronicle);
+ * const ruleEvents = timeline.getTimeline({ kind: 'rule' });
+ * const delta = timeline.getDelta(startTs, endTs);
+ *
+ * // Behavioral diff
+ * const diff = diffRegistries(snapshotBefore, snapshotAfter);
+ * console.log(formatCommitMessage(diff));
+ * ```
+ */
+
+// ── Project Chronicle (core event store) ────────────────────────────────────
+export {
+  ProjectChronicle,
+  createProjectChronicle,
+} from './project-chronicle.js';
+export type {
+  ProjectEvent,
+  ProjectEventKind,
+  ProjectChronicleOptions,
+} from './project-chronicle.js';
+
+// ── Timeline (queryable view) ───────────────────────────────────────────────
+export {
+  Timeline,
+  createTimeline,
+} from './timeline.js';
+export type {
+  TimelineFilter,
+  BehavioralDelta,
+} from './timeline.js';
+
+// ── Hooks (auto-recording) ──────────────────────────────────────────────────
+export {
+  enableProjectChronicle,
+  recordAudit,
+} from './hooks.js';
+export type {
+  ChronicleHandle,
+  EnableChronicleOptions,
+} from './hooks.js';
+
+// ── Diff (behavioral comparison) ────────────────────────────────────────────
+export {
+  diffRegistries,
+  diffContracts,
+  diffExpectations,
+  formatDelta,
+  formatCommitMessage,
+  formatReleaseNotes,
+} from './diff.js';
+export type {
+  RegistrySnapshot,
+  RegistryDiff,
+  ContractCoverage,
+  ContractDiff,
+  ExpectationSnapshot,
+  ExpectationDiff,
+  FullBehavioralDiff,
+} from './diff.js';

--- a/src/chronos/project-chronicle.ts
+++ b/src/chronos/project-chronicle.ts
@@ -1,0 +1,198 @@
+/**
+ * Project Chronicle — Core Event Store
+ *
+ * Records project lifecycle events (rule registrations, contract changes,
+ * gate transitions, build events, etc.) as a queryable, append-only log.
+ *
+ * This is the development-lifecycle counterpart to runtime Chronos:
+ * where runtime Chronos records "user typed, rule fired, fact emitted",
+ * project-level Chronos records "rule registered, contract updated,
+ * gate opened, completeness score changed."
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** The kind of project lifecycle event. */
+export type ProjectEventKind =
+  | 'rule'
+  | 'contract'
+  | 'expectation'
+  | 'gate'
+  | 'build'
+  | 'fact';
+
+/**
+ * A single project lifecycle event.
+ *
+ * Immutable once recorded — the chronicle is append-only.
+ */
+export interface ProjectEvent {
+  /** Event kind (rule, contract, expectation, gate, build, fact). */
+  kind: ProjectEventKind;
+  /**
+   * Action that occurred.
+   * Examples: 'registered', 'modified', 'removed', 'satisfied', 'violated',
+   *           'opened', 'closed', 'blocked', 'audit-complete', 'introduced', 'deprecated'.
+   */
+  action: string;
+  /** The subject (rule id, contract id, gate name, fact tag, etc.). */
+  subject: string;
+  /** Unix ms timestamp. */
+  timestamp: number;
+  /** Arbitrary metadata for this event. */
+  metadata: Record<string, unknown>;
+  /** Optional before/after diff for modifications. */
+  diff?: { before: unknown; after: unknown };
+}
+
+/** Options for creating a ProjectChronicle. */
+export interface ProjectChronicleOptions {
+  /** Maximum events to retain (0 = unlimited, default 10_000). */
+  maxEvents?: number;
+  /** Optional clock function (for testing). */
+  now?: () => number;
+}
+
+// ─── ProjectChronicle ───────────────────────────────────────────────────────
+
+/**
+ * In-memory, append-only chronicle of project lifecycle events.
+ *
+ * Thread-safe for single-threaded JS; immutable snapshots via `getEvents()`.
+ */
+export class ProjectChronicle {
+  private events: ProjectEvent[] = [];
+  private readonly maxEvents: number;
+  private readonly now: () => number;
+
+  constructor(options: ProjectChronicleOptions = {}) {
+    this.maxEvents = options.maxEvents ?? 10_000;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  // ── Recording ───────────────────────────────────────────────────────────
+
+  /**
+   * Record a project event. Returns the recorded event (with timestamp filled in).
+   */
+  record(
+    event: Omit<ProjectEvent, 'timestamp'> & { timestamp?: number },
+  ): ProjectEvent {
+    const full: ProjectEvent = {
+      kind: event.kind,
+      action: event.action,
+      subject: event.subject,
+      timestamp: event.timestamp ?? this.now(),
+      metadata: event.metadata,
+      diff: event.diff,
+    };
+    this.events.push(full);
+
+    // Evict oldest if over cap
+    if (this.maxEvents > 0 && this.events.length > this.maxEvents) {
+      this.events = this.events.slice(this.events.length - this.maxEvents);
+    }
+
+    return full;
+  }
+
+  // ── Convenience recorders ─────────────────────────────────────────────
+
+  recordRuleRegistered(ruleId: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'rule', action: 'registered', subject: ruleId, metadata: meta });
+  }
+
+  recordRuleModified(
+    ruleId: string,
+    diff: { before: unknown; after: unknown },
+    meta: Record<string, unknown> = {},
+  ): ProjectEvent {
+    return this.record({ kind: 'rule', action: 'modified', subject: ruleId, metadata: meta, diff });
+  }
+
+  recordRuleRemoved(ruleId: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'rule', action: 'removed', subject: ruleId, metadata: meta });
+  }
+
+  recordContractAdded(contractId: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'contract', action: 'added', subject: contractId, metadata: meta });
+  }
+
+  recordContractModified(
+    contractId: string,
+    diff: { before: unknown; after: unknown },
+    meta: Record<string, unknown> = {},
+  ): ProjectEvent {
+    return this.record({ kind: 'contract', action: 'modified', subject: contractId, metadata: meta, diff });
+  }
+
+  recordExpectationSatisfied(name: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'expectation', action: 'satisfied', subject: name, metadata: meta });
+  }
+
+  recordExpectationViolated(name: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'expectation', action: 'violated', subject: name, metadata: meta });
+  }
+
+  recordGateTransition(
+    gateName: string,
+    from: string,
+    to: string,
+    meta: Record<string, unknown> = {},
+  ): ProjectEvent {
+    return this.record({
+      kind: 'gate',
+      action: to,
+      subject: gateName,
+      metadata: { ...meta, from, to },
+      diff: { before: from, after: to },
+    });
+  }
+
+  recordBuildAudit(
+    score: number,
+    delta: number,
+    meta: Record<string, unknown> = {},
+  ): ProjectEvent {
+    return this.record({
+      kind: 'build',
+      action: 'audit-complete',
+      subject: 'completeness',
+      metadata: { ...meta, score, delta },
+    });
+  }
+
+  recordFactIntroduced(factTag: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'fact', action: 'introduced', subject: factTag, metadata: meta });
+  }
+
+  recordFactDeprecated(factTag: string, meta: Record<string, unknown> = {}): ProjectEvent {
+    return this.record({ kind: 'fact', action: 'deprecated', subject: factTag, metadata: meta });
+  }
+
+  // ── Access ──────────────────────────────────────────────────────────────
+
+  /** Return a shallow copy of all events. */
+  getEvents(): ProjectEvent[] {
+    return [...this.events];
+  }
+
+  /** Total number of recorded events. */
+  get size(): number {
+    return this.events.length;
+  }
+
+  /** Clear all events (primarily for testing). */
+  clear(): void {
+    this.events = [];
+  }
+}
+
+/**
+ * Create a new ProjectChronicle instance.
+ */
+export function createProjectChronicle(
+  options?: ProjectChronicleOptions,
+): ProjectChronicle {
+  return new ProjectChronicle(options);
+}

--- a/src/chronos/timeline.ts
+++ b/src/chronos/timeline.ts
@@ -1,0 +1,152 @@
+/**
+ * Timeline — Queryable view over ProjectChronicle events
+ *
+ * Provides filtering, range queries, subject history, and behavioral deltas.
+ */
+
+import type { ProjectEvent, ProjectEventKind } from './project-chronicle.js';
+import type { ProjectChronicle } from './project-chronicle.js';
+
+// ─── Filter Types ───────────────────────────────────────────────────────────
+
+/** Filter criteria for timeline queries. All fields are optional (AND logic). */
+export interface TimelineFilter {
+  /** Filter by event kind(s). */
+  kind?: ProjectEventKind | ProjectEventKind[];
+  /** Filter by action string(s). */
+  action?: string | string[];
+  /** Filter by subject (exact match or array). */
+  subject?: string | string[];
+  /** Only events at or after this timestamp (inclusive). */
+  since?: number;
+  /** Only events at or before this timestamp (inclusive). */
+  until?: number;
+}
+
+/** Summary of changes between two points in time. */
+export interface BehavioralDelta {
+  /** Time range of this delta. */
+  from: number;
+  to: number;
+  /** Events within the range. */
+  events: ProjectEvent[];
+  /** Summary counts by kind. */
+  summary: Record<ProjectEventKind, number>;
+  /** Subjects that were added (first 'registered' / 'added' / 'introduced'). */
+  added: string[];
+  /** Subjects that were removed ('removed' / 'deprecated'). */
+  removed: string[];
+  /** Subjects that were modified. */
+  modified: string[];
+}
+
+// ─── Timeline Class ─────────────────────────────────────────────────────────
+
+/**
+ * Queryable timeline wrapping a ProjectChronicle.
+ *
+ * All query methods return new arrays — never the internal event store.
+ */
+export class Timeline {
+  constructor(private readonly chronicle: ProjectChronicle) {}
+
+  // ── Queries ─────────────────────────────────────────────────────────────
+
+  /**
+   * Query events with optional filtering.
+   * Returns matching events sorted chronologically (oldest first).
+   */
+  getTimeline(filter?: TimelineFilter): ProjectEvent[] {
+    let events = this.chronicle.getEvents();
+    if (!filter) return events;
+    events = applyFilter(events, filter);
+    return events;
+  }
+
+  /**
+   * Get all events since a timestamp (inclusive).
+   */
+  getEventsSince(timestamp: number): ProjectEvent[] {
+    return this.getTimeline({ since: timestamp });
+  }
+
+  /**
+   * Compute a behavioral delta between two timestamps.
+   */
+  getDelta(from: number, to: number): BehavioralDelta {
+    const events = this.getTimeline({ since: from, until: to });
+    return buildDelta(from, to, events);
+  }
+
+  /**
+   * Get full history for a specific subject (rule id, gate name, etc.).
+   * Sorted chronologically.
+   */
+  getHistory(subjectId: string): ProjectEvent[] {
+    return this.getTimeline({ subject: subjectId });
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function applyFilter(events: ProjectEvent[], filter: TimelineFilter): ProjectEvent[] {
+  return events.filter(e => {
+    if (filter.kind) {
+      const kinds = Array.isArray(filter.kind) ? filter.kind : [filter.kind];
+      if (!kinds.includes(e.kind)) return false;
+    }
+    if (filter.action) {
+      const actions = Array.isArray(filter.action) ? filter.action : [filter.action];
+      if (!actions.includes(e.action)) return false;
+    }
+    if (filter.subject) {
+      const subjects = Array.isArray(filter.subject) ? filter.subject : [filter.subject];
+      if (!subjects.includes(e.subject)) return false;
+    }
+    if (filter.since != null && e.timestamp < filter.since) return false;
+    if (filter.until != null && e.timestamp > filter.until) return false;
+    return true;
+  });
+}
+
+const ADD_ACTIONS = new Set(['registered', 'added', 'introduced', 'opened']);
+const REMOVE_ACTIONS = new Set(['removed', 'deprecated', 'closed']);
+const MODIFY_ACTIONS = new Set(['modified', 'updated']);
+
+function buildDelta(from: number, to: number, events: ProjectEvent[]): BehavioralDelta {
+  const summary: Record<string, number> = {};
+  const added = new Set<string>();
+  const removed = new Set<string>();
+  const modified = new Set<string>();
+
+  for (const e of events) {
+    summary[e.kind] = (summary[e.kind] ?? 0) + 1;
+
+    if (ADD_ACTIONS.has(e.action)) {
+      added.add(e.subject);
+      removed.delete(e.subject); // re-added overrides removal
+    } else if (REMOVE_ACTIONS.has(e.action)) {
+      removed.add(e.subject);
+      added.delete(e.subject); // removed overrides addition
+    } else if (MODIFY_ACTIONS.has(e.action)) {
+      modified.add(e.subject);
+    }
+  }
+
+  return {
+    from,
+    to,
+    events,
+    summary: summary as Record<ProjectEventKind, number>,
+    added: [...added],
+    removed: [...removed],
+    modified: [...modified],
+  };
+}
+
+/**
+ * Create a Timeline for a given chronicle.
+ */
+export function createTimeline(chronicle: ProjectChronicle): Timeline {
+  return new Timeline(chronicle);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,51 @@ export type {
   LedgerEntryStatus,
 } from './decision-ledger/index.js';
 
+// Decision Ledger — Analyzer Engine
+export {
+  analyzeDependencyGraph,
+  findDeadRules,
+  findUnreachableStates,
+  findShadowedRules,
+  findContradictions,
+  findGaps,
+  traceDerivation,
+  traceImpact,
+  verifyContractExamples,
+  verifyInvariants,
+  findContractGaps,
+  crossReferenceContracts,
+  suggest,
+  suggestAll,
+  generateLedger,
+  formatLedger,
+  formatBuildOutput,
+  diffLedgers,
+} from './decision-ledger/index.js';
+export type {
+  FactNode,
+  DependencyEdge,
+  DependencyGraph,
+  DerivationStep,
+  DerivationChain,
+  DeadRule,
+  UnreachableState,
+  ShadowedRule,
+  Contradiction,
+  Gap,
+  ImpactReport,
+  ExampleVerification,
+  ContractVerificationResult,
+  InvariantCheck,
+  ContractCoverageGap,
+  CrossReference,
+  FindingType,
+  Suggestion,
+  AnalysisReport,
+  LedgerDiffEntry,
+  LedgerDiff,
+} from './decision-ledger/index.js';
+
 // Terminal Node Runtime
 export type {
   TerminalExecutionResult,
@@ -409,4 +454,36 @@ export type {
   BranchRulesConfig,
   PredefinedGateConfig,
 } from './project/index.js';
+
+// ── Chronos Project-Level Chronicle ─────────────────────────────────────────
+export {
+  ProjectChronicle,
+  createProjectChronicle,
+  Timeline,
+  createTimeline,
+  enableProjectChronicle,
+  recordAudit,
+  diffRegistries,
+  diffContracts,
+  diffExpectations,
+  formatDelta,
+  formatCommitMessage as formatBehavioralCommit,
+  formatReleaseNotes,
+} from './chronos/index.js';
+export type {
+  ProjectEvent,
+  ProjectEventKind,
+  ProjectChronicleOptions,
+  TimelineFilter,
+  BehavioralDelta,
+  ChronicleHandle,
+  EnableChronicleOptions,
+  RegistrySnapshot,
+  RegistryDiff,
+  ContractCoverage,
+  ContractDiff,
+  ExpectationSnapshot,
+  ExpectationDiff,
+  FullBehavioralDiff,
+} from './chronos/index.js';
 


### PR DESCRIPTION
## Summary

Adds `src/chronos/` module — project-level Chronos that records the **development lifecycle** (as opposed to runtime events).

Where runtime Chronos records "user typed, rule fired, fact emitted", project-level Chronos records "rule registered, contract updated, gate opened, completeness score changed."

## Components

### `src/chronos/project-chronicle.ts` — Core Event Store
- Append-only `ProjectChronicle` class with typed `ProjectEvent` entries
- Convenience recorders: `recordRuleRegistered`, `recordContractAdded`, `recordGateTransition`, `recordBuildAudit`, `recordFactIntroduced`, etc.
- Configurable `maxEvents` cap with FIFO eviction

### `src/chronos/timeline.ts` — Queryable Timeline
- `getTimeline(filter?)` — filter by kind, action, subject, time range (AND logic)
- `getEventsSince(timestamp)` — everything since a point in time
- `getDelta(from, to)` — behavioral delta with added/removed/modified subjects
- `getHistory(subjectId)` — full history of a specific rule/contract/gate

### `src/chronos/hooks.ts` — Auto-Recording Hooks
- `enableProjectChronicle(registry, engine)` wraps `registerRule`, `registerModule`, `step`, `checkConstraints`
- Returns `{ chronicle, disconnect }` — opt-in, cleanly reversible
- `recordAudit(chronicle, report, previousScore?)` for completeness integration

### `src/chronos/diff.ts` — Behavioral Diff Engine
- `diffRegistries(before, after)` — compare registry snapshots
- `diffContracts(before, after)` — compare contract coverage
- `diffExpectations(before, after)` — compare expectation satisfaction
- `formatDelta(diff)` — human-readable behavioral delta
- `formatCommitMessage(diff)` — conventional commit from behavioral delta
- `formatReleaseNotes(diffs[])` — aggregate deltas into release notes

## Tests

52 tests in `src/__tests__/chronos-project.test.ts` covering:
- Each event type recording
- Timeline queries (filter, range, history, delta)
- Behavioral diff (add/remove/modify rules, contracts, expectations)
- Commit message generation
- Hook auto-recording and disconnect
- End-to-end integration scenario

All existing tests continue to pass (pre-existing cli-validate failures unrelated).

## Exports

All public types and functions exported from `src/index.ts`. `formatCommitMessage` exported as `formatBehavioralCommit` to avoid collision with the existing `commitFromState` in project/.