### PR TITLE
fix: add v1.4.0 exports to browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plures/praxis",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "The Full Plures Application Framework - declarative schemas, logic engine, component generation, and local-first data",
   "type": "module",
   "packageManager": "pnpm@9.15.1",
@@ -70,21 +70,42 @@
       "default": "./dist/node/mcp/index.js"
     },
     "./expectations": {
-      "types": "./dist/node/expectations/index.d.ts",
-      "import": "./dist/node/expectations/index.js",
-      "require": "./dist/node/expectations/index.cjs",
+      "node": {
+        "types": "./dist/node/expectations/index.d.ts",
+        "import": "./dist/node/expectations/index.js",
+        "require": "./dist/node/expectations/index.cjs",
+        "default": "./dist/node/expectations/index.js"
+      },
+      "browser": {
+        "types": "./dist/browser/expectations/index.d.ts",
+        "import": "./dist/browser/expectations/index.js"
+      },
       "default": "./dist/node/expectations/index.js"
     },
     "./factory": {
-      "types": "./dist/node/factory/index.d.ts",
-      "import": "./dist/node/factory/index.js",
-      "require": "./dist/node/factory/index.cjs",
+      "node": {
+        "types": "./dist/node/factory/index.d.ts",
+        "import": "./dist/node/factory/index.js",
+        "require": "./dist/node/factory/index.cjs",
+        "default": "./dist/node/factory/index.js"
+      },
+      "browser": {
+        "types": "./dist/browser/factory/index.d.ts",
+        "import": "./dist/browser/factory/index.js"
+      },
       "default": "./dist/node/factory/index.js"
     },
     "./project": {
-      "types": "./dist/node/project/index.d.ts",
-      "import": "./dist/node/project/index.js",
-      "require": "./dist/node/project/index.cjs",
+      "node": {
+        "types": "./dist/node/project/index.d.ts",
+        "import": "./dist/node/project/index.js",
+        "require": "./dist/node/project/index.cjs",
+        "default": "./dist/node/project/index.js"
+      },
+      "browser": {
+        "types": "./dist/browser/project/index.d.ts",
+        "import": "./dist/browser/project/index.js"
+      },
       "default": "./dist/node/project/index.js"
     }
   },

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -220,3 +220,86 @@ export {
 // Unified Integration Helpers
 export type { UnifiedAppConfig, UnifiedApp } from './integrations/unified.js';
 export { createUnifiedApp, attachAllIntegrations } from './integrations/unified.js';
+
+// ── Rule Result (typed rule returns — no empty arrays) ──────────────────────
+export { RuleResult, fact } from './core/rule-result.js';
+export type { TypedRuleFn } from './core/rule-result.js';
+
+// ── UI Rules (predefined, lightweight, separate from business logic) ────────
+export {
+  uiModule,
+  createUIModule,
+  loadingGateRule,
+  errorDisplayRule,
+  offlineIndicatorRule,
+  dirtyGuardRule,
+  initGateRule,
+  viewportRule,
+  noInteractionWhileLoadingConstraint,
+  mustBeInitializedConstraint,
+  uiStateChanged,
+  navigationRequest,
+  resizeEvent,
+} from './core/ui-rules.js';
+export type { UIContext } from './core/ui-rules.js';
+
+// ── Completeness Analysis ───────────────────────────────────────────────────
+export { auditCompleteness, formatReport } from './core/completeness.js';
+export type { LogicBranch, StateField, StateTransition, CompletenessReport, CompletenessConfig } from './core/completeness.js';
+
+// ── Expectations DSL (behavioral declarations) ─────────────────────────────
+export {
+  Expectation,
+  ExpectationSet,
+  expectBehavior,
+  verify,
+  formatVerificationReport,
+} from './expectations/index.js';
+export type {
+  ExpectationCondition,
+  ConditionStatus,
+  ConditionResult,
+  ExpectationResult,
+  VerificationReport,
+  ExpectationSetOptions,
+  VerifiableRegistry,
+  VerifiableDescriptor,
+} from './expectations/index.js';
+
+// ── Rules Factory (predefined modules) ─────────────────────────────────────
+export {
+  inputRules,
+  toastRules,
+  formRules,
+  navigationRules,
+  dataRules,
+} from './factory/index.js';
+export type {
+  InputRulesConfig,
+  ToastRulesConfig,
+  FormRulesConfig,
+  NavigationRulesConfig,
+  DataRulesConfig,
+  SanitizationType,
+} from './factory/index.js';
+
+// ── Project Logic (developer workflow) ──────────────────────────────────────
+export {
+  defineGate,
+  semverContract,
+  commitFromState,
+  branchRules,
+  lintGate,
+  formatGate,
+  expectationGate,
+} from './project/index.js';
+export type {
+  GateConfig,
+  GateState,
+  GateStatus,
+  SemverContractConfig,
+  SemverReport,
+  PraxisDiff,
+  BranchRulesConfig,
+  PredefinedGateConfig,
+} from './project/index.js';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -37,7 +37,10 @@ export default defineConfig([
     name: 'browser',
     entry: {
       index: 'src/index.browser.ts',
-      'integrations/svelte': 'src/integrations/svelte.ts'
+      'integrations/svelte': 'src/integrations/svelte.ts',
+      'expectations/index': 'src/expectations/index.ts',
+      'factory/index': 'src/factory/index.ts',
+      'project/index': 'src/project/index.ts',
     },
     outDir: 'dist/browser',
     format: ['esm'],


### PR DESCRIPTION
## Problem
Sprint-log fails to load in browser:
```
SyntaxError: The requested module '@plures_praxis.js' does not provide an export named 'ExpectationSet'
```

## Root Cause
`src/index.browser.ts` was missing exports added in v1.4.0:
- `RuleResult`, `fact()` (rule-result)
- `ExpectationSet`, `expectBehavior`, `verify` (expectations)
- `inputRules`, `toastRules`, `formRules`, `navigationRules`, `dataRules` (factory)
- `defineGate`, `semverContract`, `commitFromState`, `branchRules` (project)
- `auditCompleteness`, `formatReport` (completeness)
- UI rules module

## Fix
1. Added all missing exports to `src/index.browser.ts`
2. Added `browser` conditions to sub-path exports in package.json
3. Added browser entry points to tsup config (`expectations`, `factory`, `project`)
4. Version bump: 1.4.0 → 1.4.1

## Verified
- `npx tsup` builds clean
- `grep ExpectationSet dist/browser/index.js` → found
- 603 tests pass