### PR TITLE
fix(ci): remove nonexistent @plures/pluresdb/local-first import

### DIFF
--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -5,7 +5,12 @@
  * This module defines the core interface and an in-memory implementation.
  */
 
-import type { LocalFirstOptions, PluresDBLocalFirst } from '@plures/pluresdb/local-first';
+// @plures/pluresdb/local-first subpath no longer exists; define types locally
+// These deprecated functions (createPraxisLocalFirst, createPluresDB) are slated for removal.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface LocalFirstOptions { mode?: string; [key: string]: unknown; }
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface PluresDBLocalFirst { get(key: string): Promise<unknown>; set(key: string, value: unknown): Promise<void>; }
 
 /**
  * Function to unsubscribe from a watch


### PR DESCRIPTION
Fixes DTS build failure in CI.

**Root cause:** \@plures/pluresdb\ never published a \./local-first\ subpath export. The import was dead code referencing a planned but unimplemented feature.

**Fix:** Define the types locally (both consuming functions are already \@deprecated\).