### PR TITLE
fix(ci): stub deprecated createPraxisLocalFirst — remove dead dynamic import

### DIFF
--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -5,7 +5,12 @@
  * This module defines the core interface and an in-memory implementation.
  */
 
-import type { LocalFirstOptions, PluresDBLocalFirst } from '@plures/pluresdb/local-first';
+// @plures/pluresdb/local-first subpath no longer exists; define types locally
+// These deprecated functions (createPraxisLocalFirst, createPluresDB) are slated for removal.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface LocalFirstOptions { mode?: string; [key: string]: unknown; }
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface PluresDBLocalFirst { get(key: string): Promise<unknown>; set(key: string, value: unknown): Promise<void>; }
 
 /**
  * Function to unsubscribe from a watch

--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -316,17 +316,9 @@ export interface PraxisLocalFirstOptions extends LocalFirstOptions {
 export async function createPraxisLocalFirst(
   options: PraxisLocalFirstOptions = {}
 ): Promise<PluresDBPraxisAdapter> {
-  const { pollInterval, ...localOptions } = options;
-
-  const mod = await import('@plures/pluresdb/local-first');
-  const LocalFirstCtor =
-    (mod as unknown as { PluresDBLocalFirst?: new (opts?: LocalFirstOptions) => PluresDBLocalFirst }).PluresDBLocalFirst ??
-    (mod as unknown as { default?: new (opts?: LocalFirstOptions) => PluresDBLocalFirst }).default;
-
-  if (!LocalFirstCtor) {
-    throw new Error('Failed to load PluresDBLocalFirst from @plures/pluresdb/local-first');
-  }
-
-  const db = new LocalFirstCtor(localOptions as LocalFirstOptions);
-  return new PluresDBPraxisAdapter({ db, pollInterval });
+  void options;
+  throw new Error(
+    'createPraxisLocalFirst is deprecated and @plures/pluresdb/local-first no longer exists. ' +
+    'Use PluresDBNativeAdapter from @plures/praxis-pluresdb instead.'
+  );
 }


### PR DESCRIPTION
Follows up on #377. The dynamic \import('@plures/pluresdb/local-first')\ still broke DTS generation. Since the function is deprecated and the module doesn't exist, replace body with a throw.