### PR TITLE
fix(ci): align tests with deprecated stub + add missing ava dep

### DIFF
--- a/crates/praxis-native/package.json
+++ b/crates/praxis-native/package.json
@@ -38,7 +38,8 @@
     "version": "napi version"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.7.0"
+    "@napi-rs/cli": "^3.7.0",
+    "ava": "^6.0.0"
   },
   "engines": {
     "node": ">= 18"

--- a/src/__tests__/coverage-additions-3.test.ts
+++ b/src/__tests__/coverage-additions-3.test.ts
@@ -200,10 +200,9 @@ describe('PluresDBPraxisAdapter', () => {
 });
 
 describe('createPraxisLocalFirst', () => {
-  it('resolves to a PluresDBPraxisAdapter when local-first module is available', async () => {
-    const { createPraxisLocalFirst: cpf, PluresDBPraxisAdapter: Adapter } = await import('../core/pluresdb/adapter.js');
-    const result = await cpf();
-    expect(result).toBeInstanceOf(Adapter);
+  it('throws with deprecation error since @plures/pluresdb/local-first no longer exists', async () => {
+    const { createPraxisLocalFirst: cpf } = await import('../core/pluresdb/adapter.js');
+    await expect(cpf()).rejects.toThrow('createPraxisLocalFirst is deprecated');
   });
 });
 

--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -5,7 +5,12 @@
  * This module defines the core interface and an in-memory implementation.
  */
 
-import type { LocalFirstOptions, PluresDBLocalFirst } from '@plures/pluresdb/local-first';
+// @plures/pluresdb/local-first subpath no longer exists; define types locally
+// These deprecated functions (createPraxisLocalFirst, createPluresDB) are slated for removal.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface LocalFirstOptions { mode?: string; [key: string]: unknown; }
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface PluresDBLocalFirst { get(key: string): Promise<unknown>; set(key: string, value: unknown): Promise<void>; }
 
 /**
  * Function to unsubscribe from a watch

--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -9,8 +9,6 @@
 // These deprecated functions (createPraxisLocalFirst, createPluresDB) are slated for removal.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface LocalFirstOptions { mode?: string; [key: string]: unknown; }
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface PluresDBLocalFirst { get(key: string): Promise<unknown>; set(key: string, value: unknown): Promise<void>; }
 
 /**
  * Function to unsubscribe from a watch

--- a/src/core/pluresdb/adapter.ts
+++ b/src/core/pluresdb/adapter.ts
@@ -316,17 +316,9 @@ export interface PraxisLocalFirstOptions extends LocalFirstOptions {
 export async function createPraxisLocalFirst(
   options: PraxisLocalFirstOptions = {}
 ): Promise<PluresDBPraxisAdapter> {
-  const { pollInterval, ...localOptions } = options;
-
-  const mod = await import('@plures/pluresdb/local-first');
-  const LocalFirstCtor =
-    (mod as unknown as { PluresDBLocalFirst?: new (opts?: LocalFirstOptions) => PluresDBLocalFirst }).PluresDBLocalFirst ??
-    (mod as unknown as { default?: new (opts?: LocalFirstOptions) => PluresDBLocalFirst }).default;
-
-  if (!LocalFirstCtor) {
-    throw new Error('Failed to load PluresDBLocalFirst from @plures/pluresdb/local-first');
-  }
-
-  const db = new LocalFirstCtor(localOptions as LocalFirstOptions);
-  return new PluresDBPraxisAdapter({ db, pollInterval });
+  void options;
+  throw new Error(
+    'createPraxisLocalFirst is deprecated and @plures/pluresdb/local-first no longer exists. ' +
+    'Use PluresDBNativeAdapter from @plures/praxis-pluresdb instead.'
+  );
 }


### PR DESCRIPTION
Resolves remaining CI failures:\n1. Test expected createPraxisLocalFirst to succeed — updated to expect deprecation throw\n2. praxis-native imported ava but never declared it in package.json