### PR TITLE
chore: add CODEOWNERS + SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+* @kbristol
+
+/core/ @kbristol
+/crates/ @kbristol
+/csharp/ @kbristol
+/docs/ @kbristol
+/examples/ @kbristol
+/github/ @kbristol
+/packages/ @kbristol
+/powershell/ @kbristol
+/scripts/ @kbristol
+/src/ @kbristol
+/templates/ @kbristol
+/test/ @kbristol
+/tools/ @kbristol
+/ui/ @kbristol
+/.github/ @kbristol

--- a/.github/workflows/auto-approve-copilot-runs.yml
+++ b/.github/workflows/auto-approve-copilot-runs.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - name: Generate App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: 3158960
           private-key: ${{ secrets.PRAXIS_BOT_PRIVATE_KEY }}
 
       - name: Rerun action_required Copilot runs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/auto-rebase-bot-prs.yml
+++ b/.github/workflows/auto-rebase-bot-prs.yml
@@ -22,13 +22,13 @@ jobs:
     name: Rebase Copilot PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.PLURES_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Rebase open Copilot PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.PLURES_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-feedback-loop.yml
+++ b/.github/workflows/ci-feedback-loop.yml
@@ -21,7 +21,7 @@ jobs:
     name: Deno Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup Deno
         run: |
           for i in 1 2 3; do
@@ -48,7 +48,7 @@ jobs:
 
       - name: Feed CI results into expectation system
         if: github.ref == 'refs/heads/main'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           FMT_OUTCOME: ${{ steps.fmt.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,17 +22,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -34,16 +34,16 @@ jobs:
             file: src/native_functions.rs
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Install cargo-mutants
         run: cargo install cargo-mutants
 
       - name: Cache cargo build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutants-${{ matrix.module.name }}
           path: crates/praxis-native/mutants.out/

--- a/.github/workflows/pr-lane-event-relay.yml
+++ b/.github/workflows/pr-lane-event-relay.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Dispatch lane tick to automation-infrastructure
         if: steps.preflight.outputs.enabled == 'true'
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.PLURES_PROJECTS }}
           repository: plures/automation-infrastructure

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -44,15 +44,15 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -73,7 +73,7 @@ jobs:
         run: napi build --platform --release --strip --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bindings-${{ matrix.target }}
           path: crates/praxis-native/praxis-native.*.node
@@ -83,10 +83,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -95,7 +95,7 @@ jobs:
         run: npm install -g @napi-rs/cli
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: crates/praxis-native/artifacts
 


### PR DESCRIPTION
Low-risk hygiene pilot (2026-08-04). Adds .github/CODEOWNERS (all paths -> @kbristol) and SHA-pins all third-party action refs (original tag kept as trailing comment). Internal plures/*@main reusable workflows untouched. Please review and merge.